### PR TITLE
Add SummerVentilation and deprecate bypass attr

### DIFF
--- a/honeybee_ph/bldg_segment.py
+++ b/honeybee_ph/bldg_segment.py
@@ -3,7 +3,9 @@
 
 """Building 'Segment' Level Data Attributes"""
 
+import warnings
 from copy import copy
+
 
 try:
     from typing import Any, Dict, Union
@@ -29,6 +31,10 @@ except ImportError as e:
     raise ImportError("\nFailed to import honeybee_ph:\n\t{}".format(e))
 
 
+## --------------------------------------------------------------------------------------
+## -- Enums
+
+
 class PhVentilationSummerBypassMode(enumerables.CustomEnum):
     allowed = ["1-None", "2-Temperature Controlled", "3-Enthalpy Controlled", "4-Always"]
 
@@ -51,6 +57,106 @@ class PhWindExposureType(enumerables.CustomEnum):
     def __init__(self, _value=1):
         # type: (Union[str, int]) -> None
         super(PhWindExposureType, self).__init__(_value)
+
+
+## --------------------------------------------------------------------------------------
+## -- Data Classes
+
+
+class SummerVentilation(_base._Base):
+    def __init__(
+        self,
+        _ventilation_system_ach=None,
+        _ventilation_system_summer_bypass_mode="4-Always",
+        _daytime_extract_system_ach=0.0,
+        _daytime_extract_system_fan_power_wh_m3=0.0,
+        _daytime_window_ach=0.0,
+        _nighttime_extract_system_ach=0.0,
+        _nighttime_extract_system_fan_power_wh_m3=0.0,
+        _nighttime_extract_system_heat_fraction=0.0,
+        _nighttime_extract_system_control=0.0,
+        _nighttime_window_ach=0.0,
+        _nighttime_minimum_indoor_temp_C=0.0,
+    ):
+        # type: (float | None, int | str, float, float, float, float, float, float, float, float, float) -> None
+        super(SummerVentilation, self).__init__()
+        self.ventilation_system_ach = _ventilation_system_ach
+        self.summer_bypass_mode = PhVentilationSummerBypassMode(_ventilation_system_summer_bypass_mode)
+        self.daytime_extract_system_ach = _daytime_extract_system_ach
+        self.daytime_extract_system_fan_power_wh_m3 = _daytime_extract_system_fan_power_wh_m3
+        self.daytime_window_ach = _daytime_window_ach
+        self.nighttime_extract_system_ach = _nighttime_extract_system_ach
+        self.nighttime_extract_system_fan_power_wh_m3 = _nighttime_extract_system_fan_power_wh_m3
+        self.nighttime_extract_system_heat_fraction = _nighttime_extract_system_heat_fraction
+        self.nighttime_extract_system_control = _nighttime_extract_system_control
+        self.nighttime_window_ach = _nighttime_window_ach
+        self.nighttime_minimum_indoor_temp_C = _nighttime_minimum_indoor_temp_C
+
+    def to_dict(self):
+        # type: () -> Dict[str, Any]
+        d = {}
+
+        d["identifier"] = self.identifier
+        d["user_data"] = copy(self.user_data)
+        d["display_name"] = self.display_name
+        d["summer_bypass_mode"] = self.summer_bypass_mode.to_dict()
+        d["ventilation_system_ach"] = self.ventilation_system_ach
+        d["daytime_extract_system_ach"] = self.daytime_extract_system_ach
+        d["daytime_extract_system_fan_power_wh_m3"] = self.daytime_extract_system_fan_power_wh_m3
+        d["daytime_window_ach"] = self.daytime_window_ach
+        d["nighttime_extract_system_ach"] = self.nighttime_extract_system_ach
+        d["nighttime_extract_system_fan_power_wh_m3"] = self.nighttime_extract_system_fan_power_wh_m3
+        d["nighttime_extract_system_heat_fraction"] = self.nighttime_extract_system_heat_fraction
+        d["nighttime_extract_system_control"] = self.nighttime_extract_system_control
+        d["nighttime_window_ach"] = self.nighttime_window_ach
+        d["nighttime_minimum_indoor_temp_C"] = self.nighttime_minimum_indoor_temp_C
+
+        return d
+
+    @classmethod
+    def from_dict(cls, _dict):
+        # type: (Dict[str, Any]) -> SummerVentilation
+        obj = cls()
+
+        obj.identifier = _dict.get("identifier")
+        obj.user_data = _dict.get("user_data", {})
+        obj.display_name = _dict.get("display_name")
+        obj.ventilation_system_ach = _dict.get("ventilation_system_ach")
+        obj.summer_bypass_mode = PhVentilationSummerBypassMode.from_dict(_dict.get("summer_bypass_mode", {}))
+        obj.daytime_extract_system_ach = _dict.get("daytime_extract_system_ach")
+        obj.daytime_extract_system_fan_power_wh_m3 = _dict.get("daytime_extract_system_fan_power_wh_m3")
+        obj.daytime_window_ach = _dict.get("daytime_window_ach")
+        obj.nighttime_extract_system_ach = _dict.get("nighttime_extract_system_ach")
+        obj.nighttime_extract_system_fan_power_wh_m3 = _dict.get("nighttime_extract_system_fan_power_wh_m3")
+        obj.nighttime_extract_system_heat_fraction = _dict.get("nighttime_extract_system_heat_fraction")
+        obj.nighttime_extract_system_control = _dict.get("nighttime_extract_system_control")
+        obj.nighttime_window_ach = _dict.get("nighttime_window_ach")
+        obj.nighttime_minimum_indoor_temp_C = _dict.get("nighttime_minimum_indoor_temp_C")
+
+        return obj
+
+    def __copy__(self):
+        # type: () -> SummerVentilation
+        obj = SummerVentilation()
+        obj.set_base_attrs_from_source(self)
+        obj.user_data = self.user_data
+        obj.summer_bypass_mode = PhVentilationSummerBypassMode(self.summer_bypass_mode.value)
+        obj.ventilation_system_ach = self.ventilation_system_ach
+        obj.daytime_extract_system_ach = self.daytime_extract_system_ach
+        obj.daytime_extract_system_fan_power_wh_m3 = self.daytime_extract_system_fan_power_wh_m3
+        obj.daytime_window_ach = self.daytime_window_ach
+        obj.nighttime_extract_system_ach = self.nighttime_extract_system_ach
+        obj.nighttime_extract_system_fan_power_wh_m3 = self.nighttime_extract_system_fan_power_wh_m3
+        obj.nighttime_extract_system_heat_fraction = self.nighttime_extract_system_heat_fraction
+        obj.nighttime_extract_system_control = self.nighttime_extract_system_control
+        obj.nighttime_window_ach = self.nighttime_window_ach
+        obj.nighttime_minimum_indoor_temp_C = self.nighttime_minimum_indoor_temp_C
+
+        return obj
+
+    def duplicate(self):
+        # type: () -> SummerVentilation
+        return self.__copy__()
 
 
 class SetPoints(_base._Base):
@@ -99,6 +205,10 @@ class SetPoints(_base._Base):
         return self.__copy__()
 
 
+## --------------------------------------------------------------------------------------
+## -- Building Segment Class
+
+
 class BldgSegment(_base._Base):
     def __init__(self):
         super(BldgSegment, self).__init__()
@@ -115,7 +225,29 @@ class BldgSegment(_base._Base):
         self.non_combustible_materials = False
         self.thermal_bridges = {}  # type: Dict[str, PhThermalBridge]
         self.wind_exposure_type = PhWindExposureType("1-SEVERAL_SIDES_EXPOSED_NO_SCREENING")
-        self.summer_hrv_bypass_mode = PhVentilationSummerBypassMode("4-Always")
+        self.summer_ventilation = SummerVentilation()
+
+    @property
+    def summer_hrv_bypass_mode(self):
+        ## Provide user-warning to use the new `summer_ventilation` attribute instead of the old `summer_hrv_bypass_mode` attribute"""
+        warnings.warn(
+            "The summer_hrv_bypass_mode attribute is now part of the summer_ventilation attribute. Please use the summer_ventilation attribute instead.",
+            DeprecationWarning,
+        )
+        return self.summer_ventilation.summer_bypass_mode
+
+    @summer_hrv_bypass_mode.setter
+    def summer_hrv_bypass_mode(self, value):
+        # type: (Union[str, int, PhVentilationSummerBypassMode]) -> None
+        ## Provide user-warning to use the new `summer_ventilation` attribute instead of the old `summer_hrv_bypass_mode` attribute
+        warnings.warn(
+            "The summer_hrv_bypass_mode attribute is now part of the summer_ventilation attribute. Please use the summer_ventilation attribute instead.",
+            DeprecationWarning,
+        )
+        if isinstance(value, PhVentilationSummerBypassMode):
+            self.summer_ventilation.summer_bypass_mode = value
+        else:
+            self.summer_ventilation.summer_bypass_mode = PhVentilationSummerBypassMode(value)
 
     def add_new_thermal_bridge(self, tb):
         # type: (PhThermalBridge) -> None
@@ -142,7 +274,7 @@ class BldgSegment(_base._Base):
         d["thermal_bridges"] = {}
         for tb in self.thermal_bridges.values():
             d["thermal_bridges"][str(tb.identifier)] = tb.to_dict()
-        d["summer_hrv_bypass_mode"] = self.summer_hrv_bypass_mode.to_dict()
+        d["summer_ventilation"] = self.summer_ventilation.to_dict()
         d["wind_exposure_type"] = self.wind_exposure_type.to_dict()
         return d
 
@@ -167,8 +299,13 @@ class BldgSegment(_base._Base):
         for tb_dict in _dict.get("thermal_bridges", {}).values():
             tb_obj = PhThermalBridge.from_dict(tb_dict)
             obj.thermal_bridges[tb_obj.identifier] = tb_obj
-        obj.summer_hrv_bypass_mode = PhVentilationSummerBypassMode.from_dict(_dict.get("summer_hrv_bypass_mode", {}))
+        # Support both new and old serialization formats
+        if "summer_ventilation" in _dict:
+            obj.summer_ventilation = SummerVentilation.from_dict(_dict["summer_ventilation"])
+        elif "summer_hrv_bypass_mode" in _dict:
+            obj.summer_ventilation.summer_bypass_mode = PhVentilationSummerBypassMode.from_dict(_dict["summer_hrv_bypass_mode"])  # type: ignore
         obj.wind_exposure_type = PhWindExposureType.from_dict(_dict.get("wind_exposure_type", {}))
+
         return obj
 
     def __copy__(self):
@@ -188,7 +325,7 @@ class BldgSegment(_base._Base):
         new_obj.thermal_bridges = {}
         for tb_k, tb_v in self.thermal_bridges.items():
             new_obj.thermal_bridges[tb_k] = tb_v.duplicate()
-        new_obj.summer_hrv_bypass_mode = PhVentilationSummerBypassMode(self.summer_hrv_bypass_mode.value)
+        new_obj.summer_ventilation = self.summer_ventilation.duplicate()
         new_obj.wind_exposure_type = PhWindExposureType(self.wind_exposure_type.value)
         return new_obj
 

--- a/tests/test_honeybee_ph/test_bldg_segment.py
+++ b/tests/test_honeybee_ph/test_bldg_segment.py
@@ -1,7 +1,17 @@
+import warnings
+
 from ladybug_geometry.geometry3d import LineSegment3D, Point3D
 
 from honeybee_energy_ph.construction.thermal_bridge import PhThermalBridge
-from honeybee_ph.bldg_segment import BldgSegment, PhVentilationSummerBypassMode, PhWindExposureType, SetPoints
+from honeybee_ph.bldg_segment import (
+    BldgSegment,
+    PhVentilationSummerBypassMode,
+    PhWindExposureType,
+    SetPoints,
+    SummerVentilation,
+)
+
+# -- SetPoints -----------------------------------------------------------------
 
 
 def test_set_points_round_trip():
@@ -26,6 +36,119 @@ def test_set_points_duplicate():
     o2 = o1.duplicate()
 
     assert o1.to_dict() == o2.to_dict()
+
+
+# -- SummerVentilation ---------------------------------------------------------
+
+
+def test_summer_ventilation_default():
+    sv = SummerVentilation()
+    assert sv.summer_bypass_mode.value == "4-ALWAYS"
+    assert sv.ventilation_system_ach is None
+    assert sv.daytime_extract_system_ach == 0.0
+    assert sv.daytime_extract_system_fan_power_wh_m3 == 0.0
+    assert sv.daytime_window_ach == 0.0
+    assert sv.nighttime_extract_system_ach == 0.0
+    assert sv.nighttime_extract_system_fan_power_wh_m3 == 0.0
+    assert sv.nighttime_extract_system_heat_fraction == 0.0
+    assert sv.nighttime_extract_system_control == 0.0
+    assert sv.nighttime_window_ach == 0.0
+    assert sv.nighttime_minimum_indoor_temp_C == 0.0
+
+
+def test_summer_ventilation_init_with_args():
+    sv = SummerVentilation(
+        _ventilation_system_ach=1.5,
+        _ventilation_system_summer_bypass_mode=2,
+        _daytime_extract_system_ach=0.3,
+        _daytime_extract_system_fan_power_wh_m3=0.45,
+        _daytime_window_ach=0.5,
+        _nighttime_extract_system_ach=0.6,
+        _nighttime_extract_system_fan_power_wh_m3=0.55,
+        _nighttime_extract_system_heat_fraction=0.7,
+        _nighttime_extract_system_control=0.8,
+        _nighttime_window_ach=0.9,
+        _nighttime_minimum_indoor_temp_C=18.0,
+    )
+    assert sv.ventilation_system_ach == 1.5
+    assert sv.summer_bypass_mode.value == "2-TEMPERATURE CONTROLLED"
+    assert sv.daytime_extract_system_ach == 0.3
+    assert sv.daytime_extract_system_fan_power_wh_m3 == 0.45
+    assert sv.daytime_window_ach == 0.5
+    assert sv.nighttime_extract_system_ach == 0.6
+    assert sv.nighttime_extract_system_fan_power_wh_m3 == 0.55
+    assert sv.nighttime_extract_system_heat_fraction == 0.7
+    assert sv.nighttime_extract_system_control == 0.8
+    assert sv.nighttime_window_ach == 0.9
+    assert sv.nighttime_minimum_indoor_temp_C == 18.0
+
+
+def test_summer_ventilation_round_trip():
+    sv1 = SummerVentilation()
+    d1 = sv1.to_dict()
+    sv2 = SummerVentilation.from_dict(d1)
+
+    assert sv2.to_dict() == d1
+    assert sv2.summer_bypass_mode.value == sv1.summer_bypass_mode.value
+
+
+def test_summer_ventilation_round_trip_custom():
+    sv1 = SummerVentilation()
+    sv1.summer_bypass_mode = PhVentilationSummerBypassMode(2)
+    sv1.ventilation_system_ach = 2.5
+    sv1.daytime_extract_system_ach = 0.4
+    sv1.daytime_extract_system_fan_power_wh_m3 = 0.55
+    sv1.daytime_window_ach = 0.6
+    sv1.nighttime_extract_system_ach = 0.7
+    sv1.nighttime_extract_system_fan_power_wh_m3 = 0.65
+    sv1.nighttime_extract_system_heat_fraction = 0.8
+    sv1.nighttime_extract_system_control = 0.9
+    sv1.nighttime_window_ach = 1.0
+    sv1.nighttime_minimum_indoor_temp_C = 16.0
+
+    d1 = sv1.to_dict()
+    sv2 = SummerVentilation.from_dict(d1)
+
+    assert sv2.summer_bypass_mode.value == "2-TEMPERATURE CONTROLLED"
+    assert sv2.ventilation_system_ach == 2.5
+    assert sv2.daytime_extract_system_ach == 0.4
+    assert sv2.daytime_extract_system_fan_power_wh_m3 == 0.55
+    assert sv2.daytime_window_ach == 0.6
+    assert sv2.nighttime_extract_system_ach == 0.7
+    assert sv2.nighttime_extract_system_fan_power_wh_m3 == 0.65
+    assert sv2.nighttime_extract_system_heat_fraction == 0.8
+    assert sv2.nighttime_extract_system_control == 0.9
+    assert sv2.nighttime_window_ach == 1.0
+    assert sv2.nighttime_minimum_indoor_temp_C == 16.0
+    assert sv2.to_dict() == d1
+
+
+def test_summer_ventilation_duplicate():
+    sv1 = SummerVentilation()
+    sv1.summer_bypass_mode = PhVentilationSummerBypassMode(3)
+    sv1.ventilation_system_ach = 1.2
+    sv1.daytime_extract_system_ach = 0.3
+    sv1.daytime_extract_system_fan_power_wh_m3 = 0.4
+    sv1.daytime_window_ach = 0.5
+    sv1.nighttime_extract_system_ach = 0.6
+    sv1.nighttime_extract_system_fan_power_wh_m3 = 0.7
+    sv1.nighttime_extract_system_heat_fraction = 0.8
+    sv1.nighttime_extract_system_control = 0.9
+    sv1.nighttime_window_ach = 1.0
+    sv1.nighttime_minimum_indoor_temp_C = 15.0
+
+    sv2 = sv1.duplicate()
+
+    assert sv2.summer_bypass_mode.value == sv1.summer_bypass_mode.value
+    assert sv2.ventilation_system_ach == sv1.ventilation_system_ach
+    assert sv2.nighttime_minimum_indoor_temp_C == sv1.nighttime_minimum_indoor_temp_C
+    assert sv2.to_dict() == sv1.to_dict()
+    # Verify it's a true copy, not a reference
+    assert sv2 is not sv1
+    assert sv2.summer_bypass_mode is not sv1.summer_bypass_mode
+
+
+# -- BldgSegment ---------------------------------------------------------------
 
 
 def test_default_bdg_segment_round_trip():
@@ -95,21 +218,161 @@ def test_bdg_segment_w_user_data_duplicate():
     assert o1.to_dict() == o2.to_dict()
 
 
-def test_set_summer_bypass_mode_roundtrip():
+# -- Deprecated summer_hrv_bypass_mode property --------------------------------
+
+
+def test_deprecated_summer_hrv_bypass_mode_getter():
+    seg = BldgSegment()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        _ = seg.summer_hrv_bypass_mode
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert "summer_ventilation" in str(w[0].message)
+
+
+def test_deprecated_summer_hrv_bypass_mode_setter():
+    seg = BldgSegment()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        seg.summer_hrv_bypass_mode = PhVentilationSummerBypassMode(2)
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+    # Verify value was set through to the underlying object
+    assert seg.summer_ventilation.summer_bypass_mode.value == "2-TEMPERATURE CONTROLLED"
+
+
+def test_deprecated_summer_hrv_bypass_mode_setter_with_int():
+    seg = BldgSegment()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        seg.summer_hrv_bypass_mode = 3
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+    assert seg.summer_ventilation.summer_bypass_mode.value == "3-ENTHALPY CONTROLLED"
+
+
+def test_deprecated_summer_hrv_bypass_mode_setter_with_string():
+    seg = BldgSegment()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        seg.summer_hrv_bypass_mode = "2-Temperature Controlled"
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+    assert seg.summer_ventilation.summer_bypass_mode.value == "2-TEMPERATURE CONTROLLED"
+
+
+def test_set_summer_bypass_mode_roundtrip_via_deprecated():
+    """Round-trip through the deprecated property still works."""
     seg1 = BldgSegment()
-    seg1.summer_hrv_bypass_mode = PhVentilationSummerBypassMode(2)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        seg1.summer_hrv_bypass_mode = PhVentilationSummerBypassMode(2)
 
     d1 = seg1.to_dict()
     seg2 = BldgSegment.from_dict(d1)
-    assert seg2.summer_hrv_bypass_mode == seg1.summer_hrv_bypass_mode
+
+    assert seg2.summer_ventilation.summer_bypass_mode.value == "2-TEMPERATURE CONTROLLED"
 
 
-def test_set_summer_bypass_mode_duplicate():
+def test_set_summer_bypass_mode_roundtrip_via_new_api():
+    """Round-trip through the new summer_ventilation API."""
     seg1 = BldgSegment()
-    seg1.summer_hrv_bypass_mode = PhVentilationSummerBypassMode(2)
+    seg1.summer_ventilation.summer_bypass_mode = PhVentilationSummerBypassMode(2)
+
+    d1 = seg1.to_dict()
+    seg2 = BldgSegment.from_dict(d1)
+
+    assert seg2.summer_ventilation.summer_bypass_mode.value == "2-TEMPERATURE CONTROLLED"
+    assert seg2.to_dict() == d1
+
+
+def test_set_summer_bypass_mode_duplicate_via_deprecated():
+    seg1 = BldgSegment()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        seg1.summer_hrv_bypass_mode = PhVentilationSummerBypassMode(2)
 
     seg2 = seg1.duplicate()
-    assert seg2.summer_hrv_bypass_mode == seg1.summer_hrv_bypass_mode
+
+    assert seg2.summer_ventilation.summer_bypass_mode.value == "2-TEMPERATURE CONTROLLED"
+    assert seg2.to_dict() == seg1.to_dict()
+
+
+# -- Old serialization format backwards compat ---------------------------------
+
+
+def test_from_dict_with_old_format():
+    """Old JSON files have 'summer_hrv_bypass_mode' at the top level, not 'summer_ventilation'."""
+    seg1 = BldgSegment()
+    d1 = seg1.to_dict()
+
+    # Simulate an old-format dict: replace 'summer_ventilation' with flat 'summer_hrv_bypass_mode'
+    summer_vent_dict = d1.pop("summer_ventilation")
+    d1["summer_hrv_bypass_mode"] = summer_vent_dict["summer_bypass_mode"]
+
+    seg2 = BldgSegment.from_dict(d1)
+
+    # The bypass mode value should survive the old-format round-trip
+    assert seg2.summer_ventilation.summer_bypass_mode.value == "4-ALWAYS"
+
+
+def test_from_dict_with_old_format_custom_value():
+    """Old JSON with a non-default bypass mode deserializes correctly."""
+    seg1 = BldgSegment()
+    d1 = seg1.to_dict()
+
+    # Simulate old format with custom value
+    d1.pop("summer_ventilation")
+    d1["summer_hrv_bypass_mode"] = {"value": "2-TEMPERATURE CONTROLLED"}
+
+    seg2 = BldgSegment.from_dict(d1)
+
+    assert seg2.summer_ventilation.summer_bypass_mode.value == "2-TEMPERATURE CONTROLLED"
+
+
+def test_from_dict_new_format_takes_precedence():
+    """If both keys exist (shouldn't happen normally), new format wins."""
+    seg1 = BldgSegment()
+    d1 = seg1.to_dict()
+
+    # Add an old key alongside the new one — new key should win
+    d1["summer_hrv_bypass_mode"] = {"value": "1-NONE"}
+
+    seg2 = BldgSegment.from_dict(d1)
+
+    # New format (4-ALWAYS default) takes precedence over old key (1-NONE)
+    assert seg2.summer_ventilation.summer_bypass_mode.value == "4-ALWAYS"
+
+
+def test_to_dict_uses_new_format():
+    """to_dict should serialize under 'summer_ventilation', not 'summer_hrv_bypass_mode'."""
+    seg = BldgSegment()
+    d = seg.to_dict()
+
+    assert "summer_ventilation" in d
+    assert "summer_hrv_bypass_mode" not in d
+    sv_dict = d["summer_ventilation"]
+    assert "summer_bypass_mode" in sv_dict
+    assert "ventilation_system_ach" in sv_dict
+    assert "daytime_extract_system_ach" in sv_dict
+    assert "daytime_extract_system_fan_power_wh_m3" in sv_dict
+    assert "daytime_window_ach" in sv_dict
+    assert "nighttime_extract_system_ach" in sv_dict
+    assert "nighttime_extract_system_fan_power_wh_m3" in sv_dict
+    assert "nighttime_extract_system_heat_fraction" in sv_dict
+    assert "nighttime_extract_system_control" in sv_dict
+    assert "nighttime_window_ach" in sv_dict
+    assert "nighttime_minimum_indoor_temp_C" in sv_dict
+
+
+def test_default_summer_bypass_mode_preserved():
+    """The default bypass mode should be '4-Always' to match the old behavior."""
+    seg = BldgSegment()
+    assert seg.summer_ventilation.summer_bypass_mode.value == "4-ALWAYS"
+
+
+# -- Wind exposure type --------------------------------------------------------
 
 
 def test_set_wind_exposure_type_roundtrip():

--- a/uv.lock
+++ b/uv.lock
@@ -253,7 +253,7 @@ wheels = [
 
 [[package]]
 name = "honeybee-ph"
-version = "1.32.8"
+version = "1.32.9"
 source = { editable = "." }
 dependencies = [
     { name = "honeybee-core" },


### PR DESCRIPTION
Introduce a new SummerVentilation data class to encapsulate summer ventilation parameters and replace the previous summer_hrv_bypass_mode attribute on BldgSegment. BldgSegment now exposes a summer_ventilation attribute and provides a deprecated summer_hrv_bypass_mode property (getter/setter) that emits DeprecationWarning and proxies to the new object. Serialization, copying, duplication and from_dict/to_dict were updated to use summer_ventilation, while still supporting the old top-level summer_hrv_bypass_mode key for backward compatibility. Added comprehensive tests for SummerVentilation, the deprecated property behavior, old/new-format deserialization, and to_dict output. Also added a warnings import and bumped honeybee-ph version in uv.lock.