### PR TITLE
[codex] Add ventilator subsoil heat exchange fields

### DIFF
--- a/honeybee_phhvac/ventilation.py
+++ b/honeybee_phhvac/ventilation.py
@@ -54,6 +54,8 @@ class Ventilator(_base._PhHVACBase):
         frost_protection_reqd (bool): Whether frost protection is required.
         temperature_below_defrost_used (float): Temperature threshold for defrost activation (C).
         in_conditioned_space (bool): Whether the unit is located in conditioned space.
+        subsoil_heat_exchange_efficiency (Optional[float]): Ground-loop effectiveness coefficient (0-1).
+        preheated_intake_temperature_c (Optional[float]): Intake-air temperature after subsoil heat exchange (C).
     """
 
     def __init__(self):
@@ -67,6 +69,8 @@ class Ventilator(_base._PhHVACBase):
         self.frost_protection_reqd = True  # type: bool
         self.temperature_below_defrost_used = -5  # type: float
         self.in_conditioned_space = True  # type: bool
+        self.subsoil_heat_exchange_efficiency = None  # type: Optional[float]
+        self.preheated_intake_temperature_c = None  # type: Optional[float]
 
     def to_dict(self):
         # type: () -> dict[str, Any]
@@ -78,6 +82,10 @@ class Ventilator(_base._PhHVACBase):
         d["frost_protection_reqd"] = self.frost_protection_reqd
         d["temperature_below_defrost_used"] = self.temperature_below_defrost_used
         d["in_conditioned_space"] = self.in_conditioned_space
+        if self.subsoil_heat_exchange_efficiency is not None:
+            d["subsoil_heat_exchange_efficiency"] = self.subsoil_heat_exchange_efficiency
+        if self.preheated_intake_temperature_c is not None:
+            d["preheated_intake_temperature_c"] = self.preheated_intake_temperature_c
         return d
 
     @classmethod
@@ -94,6 +102,8 @@ class Ventilator(_base._PhHVACBase):
         obj.frost_protection_reqd = _input_dict["frost_protection_reqd"]
         obj.temperature_below_defrost_used = _input_dict["temperature_below_defrost_used"]
         obj.in_conditioned_space = _input_dict["in_conditioned_space"]
+        obj.subsoil_heat_exchange_efficiency = _input_dict.get("subsoil_heat_exchange_efficiency", None)
+        obj.preheated_intake_temperature_c = _input_dict.get("preheated_intake_temperature_c", None)
         return obj
 
     def duplicate(self):
@@ -110,6 +120,8 @@ class Ventilator(_base._PhHVACBase):
         new_obj.frost_protection_reqd = self.frost_protection_reqd
         new_obj.temperature_below_defrost_used = self.temperature_below_defrost_used
         new_obj.in_conditioned_space = self.in_conditioned_space
+        new_obj.subsoil_heat_exchange_efficiency = self.subsoil_heat_exchange_efficiency
+        new_obj.preheated_intake_temperature_c = self.preheated_intake_temperature_c
         return new_obj
 
     def __lt__(self, other):

--- a/tests/test_honeybee_phhvac/test_devices/test_ventilator.py
+++ b/tests/test_honeybee_phhvac/test_devices/test_ventilator.py
@@ -15,6 +15,9 @@ def test_default_ventilator():
 def test_dict_round_trip_default_ventilator():
     o1 = ventilation.Ventilator()
     d1 = o1.to_dict()
+    assert "subsoil_heat_exchange_efficiency" not in d1
+    assert "preheated_intake_temperature_c" not in d1
+
     o2 = ventilation.Ventilator.from_dict(d1)
 
     assert o1.to_dict() == o2.to_dict()
@@ -73,9 +76,54 @@ def test_custom_ventilator():
     o1.frost_protection_reqd = False
     o1.temperature_below_defrost_used = -12
     o1.in_conditioned_space = False
+    o1.subsoil_heat_exchange_efficiency = 0.3
+    o1.preheated_intake_temperature_c = 8.0
 
     assert o1.ToString()
 
     d = o1.to_dict()
     o2 = ventilation.Ventilator.from_dict(d)
     assert o2.to_dict() == o1.to_dict()
+
+
+def test_default_ventilator_from_legacy_dict():
+    o1 = ventilation.Ventilator()
+    d1 = o1.to_dict()
+
+    o2 = ventilation.Ventilator.from_dict(d1)
+    assert o2.subsoil_heat_exchange_efficiency is None
+    assert o2.preheated_intake_temperature_c is None
+    assert o2.to_dict() == d1
+
+
+def test_subsoil_heat_exchange_round_trip():
+    o1 = ventilation.Ventilator()
+    o1.subsoil_heat_exchange_efficiency = 0.3
+    o1.preheated_intake_temperature_c = 8.0
+
+    o2 = o1.duplicate()
+    assert o2.subsoil_heat_exchange_efficiency == 0.3
+    assert o2.preheated_intake_temperature_c == 8.0
+
+    d1 = o2.to_dict()
+    assert d1["subsoil_heat_exchange_efficiency"] == 0.3
+    assert d1["preheated_intake_temperature_c"] == 8.0
+
+    o3 = ventilation.Ventilator.from_dict(d1)
+    assert o3.subsoil_heat_exchange_efficiency == 0.3
+    assert o3.preheated_intake_temperature_c == 8.0
+    assert o3.to_dict() == d1
+
+
+def test_zero_subsoil_heat_exchange_efficiency_is_serialized():
+    o1 = ventilation.Ventilator()
+    o1.subsoil_heat_exchange_efficiency = 0.0
+
+    d1 = o1.to_dict()
+    assert "subsoil_heat_exchange_efficiency" in d1
+    assert d1["subsoil_heat_exchange_efficiency"] == 0.0
+    assert "preheated_intake_temperature_c" not in d1
+
+    o2 = ventilation.Ventilator.from_dict(d1)
+    assert o2.subsoil_heat_exchange_efficiency == 0.0
+    assert o2.preheated_intake_temperature_c is None


### PR DESCRIPTION
## Summary

- Add optional `Ventilator.subsoil_heat_exchange_efficiency` and `Ventilator.preheated_intake_temperature_c` fields for PHPP subsoil heat-exchanger inputs.
- Preserve backward compatibility by omitting both keys from `to_dict()` when unset and reading legacy dicts with `.get(...)`.
- Add ventilator tests for legacy dicts, default serialization omission, duplicate/dict round-trips, and explicit `0.0` SHX efficiency.

## Validation

- `python3 -m pytest tests/test_honeybee_phhvac/test_devices/test_ventilator.py tests/test_honeybee_phhvac/test_devices/test_hot_water_heaters.py`
- `git diff --check`