### PR TITLE
Add ihg_usage_profile (season/block) to PhSupportiveDevice

### DIFF
--- a/honeybee_phhvac/supportive_device.py
+++ b/honeybee_phhvac/supportive_device.py
@@ -16,6 +16,31 @@ except ImportError as e:
     raise ImportError("\nFailed to import honeybee_phhvac:\n\t{}".format(e))
 
 
+# -- IHG usage-profile int codes. Shared contract across honeybee-ph / PHX /
+# -- OpenPH: which PHPP 'Aux Electricity' block (and therefore which season and
+# -- utilization period) a device's internal heat gain lands in.
+IHG_USAGE_PROFILE_ALL_YEAR = 1  # Other block (rows 71-79): both seasons, / 8.76 kh
+IHG_USAGE_PROFILE_WINTER = 2  # Heating/ventilation winter block (rows 15-31)
+IHG_USAGE_PROFILE_SUMMER = 3  # Cooling/ventilation summer + dehumidification (rows 35-57)
+IHG_USAGE_PROFILE_NONE = 4  # DHW block (rows 59-69): 0 IHG (already booked in DHW distribution)
+
+# -- Default IHG usage-profile keyed off device_type, so a DHW pump never
+# -- defaults into the cooling balance (the over-count OpenPH corrected).
+# -- Unlisted/custom device types fall back to ALL_YEAR.
+_DEFAULT_IHG_USAGE_PROFILE_BY_DEVICE_TYPE = {
+    4: IHG_USAGE_PROFILE_WINTER,  # Heat Circulation Pump
+    6: IHG_USAGE_PROFILE_NONE,  # DHW Circulation Pump
+    7: IHG_USAGE_PROFILE_NONE,  # DHW Storage Load Pump
+    10: IHG_USAGE_PROFILE_ALL_YEAR,  # Other / Custom
+}
+
+
+def default_ihg_usage_profile(device_type):
+    # type: (int) -> int
+    """Return the default IHG usage-profile int code for a supportive-device type."""
+    return _DEFAULT_IHG_USAGE_PROFILE_BY_DEVICE_TYPE.get(device_type, IHG_USAGE_PROFILE_ALL_YEAR)
+
+
 class PhSupportiveDevice(_base._PhHVACBase):
     """Auxiliary energy supportive device for Passive House HVAC systems.
 
@@ -27,18 +52,34 @@ class PhSupportiveDevice(_base._PhHVACBase):
         norm_energy_demand_W (float): Normalized energy demand in Watts.
         annual_period_operation_khrs (float): Annual operating period in thousands of hours.
         ihg_utilization_factor (float): Fraction of energy that becomes internal heat gain inside the envelope (0.0-1.0).
+        ihg_usage_profile (int): PHPP season/block the device's IHG lands in (1=all-year, 2=winter, 3=summer, 4=none/DHW).
     """
 
     def __init__(self):
         # type: () -> None
         super(PhSupportiveDevice, self).__init__()
         self.display_name = "__unnamed_device__"
-        self.device_type = 10
+        self.device_type = 10  # setter seeds ihg_usage_profile off this type
         self.quantity = 1
         self.in_conditioned_space = True
         self.norm_energy_demand_W = 1.0
         self.annual_period_operation_khrs = 8.760  # 100% of the year
         self.ihg_utilization_factor = 1.0  # Fraction of energy that becomes IHG inside envelope [0.0-1.0]
+
+    @property
+    def device_type(self):
+        # type: () -> int
+        return self._device_type
+
+    @device_type.setter
+    def device_type(self, value):
+        # type: (int) -> None
+        self._device_type = value
+        # Re-seed the IHG season/block default for the new type, so a DHW pump
+        # can never carry the all-year default into the cooling balance. Explicit
+        # ihg_usage_profile assignments must therefore follow device_type -- as
+        # __init__, base_attrs_from_dict, duplicate, and the GH factory all do.
+        self.ihg_usage_profile = default_ihg_usage_profile(value)
 
     def to_dict(self):
         # type: () -> Dict[str, Any]
@@ -51,6 +92,7 @@ class PhSupportiveDevice(_base._PhHVACBase):
         d["norm_energy_demand_W"] = self.norm_energy_demand_W
         d["annual_period_operation_khrs"] = self.annual_period_operation_khrs
         d["ihg_utilization_factor"] = self.ihg_utilization_factor
+        d["ihg_usage_profile"] = self.ihg_usage_profile
         return d
 
     def base_attrs_from_dict(self, _input_dict):
@@ -64,6 +106,9 @@ class PhSupportiveDevice(_base._PhHVACBase):
         self.norm_energy_demand_W = _input_dict["norm_energy_demand_W"]
         self.annual_period_operation_khrs = _input_dict["annual_period_operation_khrs"]
         self.ihg_utilization_factor = _input_dict.get("ihg_utilization_factor", 1.0)
+        # -- Legacy dicts (pre-seasonal-IHG) have no profile; derive it from device_type
+        # -- so an old DHW pump stays NONE rather than defaulting into the cooling balance.
+        self.ihg_usage_profile = _input_dict.get("ihg_usage_profile", default_ihg_usage_profile(self.device_type))
         return self
 
     def check_dict_type(self, _input_dict):
@@ -200,4 +245,5 @@ class PhSupportiveDevice(_base._PhHVACBase):
         obj.norm_energy_demand_W = self.norm_energy_demand_W
         obj.annual_period_operation_khrs = self.annual_period_operation_khrs
         obj.ihg_utilization_factor = self.ihg_utilization_factor
+        obj.ihg_usage_profile = self.ihg_usage_profile
         return obj

--- a/tests/test_honeybee_phhvac/test_devices/test_suppportive_device.py
+++ b/tests/test_honeybee_phhvac/test_devices/test_suppportive_device.py
@@ -1,4 +1,10 @@
-from honeybee_phhvac.supportive_device import PhSupportiveDevice
+from honeybee_phhvac.supportive_device import (
+    IHG_USAGE_PROFILE_ALL_YEAR,
+    IHG_USAGE_PROFILE_NONE,
+    IHG_USAGE_PROFILE_WINTER,
+    PhSupportiveDevice,
+    default_ihg_usage_profile,
+)
 
 
 def test_PhSupportiveDevice_to_dict():
@@ -20,6 +26,7 @@ def test_PhSupportiveDevice_to_dict():
         "norm_energy_demand_W": 500,
         "annual_period_operation_khrs": 2000,
         "ihg_utilization_factor": 1.0,
+        "ihg_usage_profile": 1,  # device_type 20 is unlisted -> ALL_YEAR default
         "user_data": {},
     }
 
@@ -157,3 +164,92 @@ def test_PhSupportiveDevice_ihg_utilization_factor_backwards_compat():
     # No "ihg_utilization_factor" key in dict
     device = PhSupportiveDevice.from_dict(input_dict)
     assert device.ihg_utilization_factor == 1.0
+
+
+# -- IHG Usage-Profile (season/block) Tests --
+
+
+def test_PhSupportiveDevice_ihg_usage_profile_default_is_all_year():
+    """Default device (device_type 10 / Other) is an all-year IHG contributor."""
+    device = PhSupportiveDevice()
+    assert device.ihg_usage_profile == IHG_USAGE_PROFILE_ALL_YEAR
+
+
+def test_PhSupportiveDevice_device_type_setter_reseeds_profile():
+    """Create-then-assign: setting device_type to a DHW pump re-seeds the profile to NONE."""
+    device = PhSupportiveDevice()  # device_type 10 -> ALL_YEAR
+    assert device.ihg_usage_profile == IHG_USAGE_PROFILE_ALL_YEAR
+    device.device_type = 6  # DHW Circulation Pump
+    assert device.ihg_usage_profile == IHG_USAGE_PROFILE_NONE
+    assert device.to_dict()["ihg_usage_profile"] == IHG_USAGE_PROFILE_NONE
+
+
+def test_PhSupportiveDevice_explicit_profile_survives_when_set_after_device_type():
+    """An explicit profile set after device_type is preserved (real construction order)."""
+    device = PhSupportiveDevice()
+    device.device_type = 10
+    device.ihg_usage_profile = IHG_USAGE_PROFILE_WINTER
+    assert device.ihg_usage_profile == IHG_USAGE_PROFILE_WINTER
+
+
+def test_default_ihg_usage_profile_mapping():
+    """Each device_type maps to the PHPP block it belongs to; unlisted -> ALL_YEAR."""
+    assert default_ihg_usage_profile(4) == IHG_USAGE_PROFILE_WINTER  # Heat Circulation Pump
+    assert default_ihg_usage_profile(6) == IHG_USAGE_PROFILE_NONE  # DHW Circulation Pump
+    assert default_ihg_usage_profile(7) == IHG_USAGE_PROFILE_NONE  # DHW Storage Load Pump
+    assert default_ihg_usage_profile(10) == IHG_USAGE_PROFILE_ALL_YEAR  # Other / Custom
+    assert default_ihg_usage_profile(999) == IHG_USAGE_PROFILE_ALL_YEAR  # unknown -> fallback
+
+
+def test_PhSupportiveDevice_ihg_usage_profile_roundtrip():
+    device = PhSupportiveDevice()
+    device.ihg_usage_profile = IHG_USAGE_PROFILE_WINTER
+    new_device = PhSupportiveDevice.from_dict(device.to_dict())
+    assert new_device.ihg_usage_profile == IHG_USAGE_PROFILE_WINTER
+    assert device == new_device
+
+
+def test_PhSupportiveDevice_ihg_usage_profile_duplicate():
+    device = PhSupportiveDevice()
+    device.ihg_usage_profile = IHG_USAGE_PROFILE_WINTER
+    new_device = device.duplicate()
+    assert new_device.ihg_usage_profile == IHG_USAGE_PROFILE_WINTER
+    assert device == new_device
+    assert id(device) != id(new_device)
+
+
+def test_PhSupportiveDevice_ihg_usage_profile_backwards_compat_dhw():
+    """A legacy DHW-pump dict with no profile key must default to NONE, not into the balance."""
+    input_dict = {
+        "identifier": "1234",
+        "device_class_name": "PhSupportiveDevice",
+        "display_name": "DHW Circulation Pump",
+        "device_type": 6,  # DHW Circulation Pump
+        "quantity": 1,
+        "in_conditioned_space": True,
+        "norm_energy_demand_W": 1.0,
+        "annual_period_operation_khrs": 8.760,
+        "ihg_utilization_factor": 1.0,
+        "user_data": {},
+    }
+    # No "ihg_usage_profile" key in dict -> derive from device_type
+    device = PhSupportiveDevice.from_dict(input_dict)
+    assert device.ihg_usage_profile == IHG_USAGE_PROFILE_NONE
+
+
+def test_PhSupportiveDevice_ihg_usage_profile_backwards_compat_other():
+    """A legacy 'Other' dict with no profile key defaults to ALL_YEAR."""
+    input_dict = {
+        "identifier": "1234",
+        "device_class_name": "PhSupportiveDevice",
+        "display_name": "Humidifier",
+        "device_type": 10,  # Other / Custom
+        "quantity": 1,
+        "in_conditioned_space": True,
+        "norm_energy_demand_W": 1.0,
+        "annual_period_operation_khrs": 8.760,
+        "ihg_utilization_factor": 1.0,
+        "user_data": {},
+    }
+    device = PhSupportiveDevice.from_dict(input_dict)
+    assert device.ihg_usage_profile == IHG_USAGE_PROFILE_ALL_YEAR


### PR DESCRIPTION
Aux-electricity supportive devices contribute internal heat gain to a season-specific PHPP 'Aux Electricity' block (a defrost heater only in winter, a DHW pump not at all). Add an `ihg_usage_profile` int field (1=all-year, 2=winter, 3=summer, 4=none/DHW) so the season a device's IHG lands in is carried as real data downstream (PHX -> OpenPH).

- module-level int contract + `default_ihg_usage_profile(device_type)` map (DHW pumps -> NONE, heat pump -> WINTER, other -> ALL_YEAR, else ALL_YEAR)
- `device_type` is now a property whose setter re-seeds the profile default, so a DHW pump can never carry the all-year default into the cooling balance regardless of construction order
- serialize in to_dict / base_attrs_from_dict (legacy dicts derive the default from device_type) / duplicate
- tests: default-by-type map, round-trip, duplicate, legacy back-compat (DHW -> NONE), create-then-assign re-seed, explicit-profile preservation