### PR TITLE
Record Space.from_room Phase 04 release handoff

### DIFF
--- a/planning/STATUS.md
+++ b/planning/STATUS.md
@@ -9,7 +9,7 @@ _Last updated: 2026-08-14_
 | Item | Kind | Status | Pointer |
 |------|------|--------|---------|
 | EPW-derived preliminary monthly climate + provenance/readiness | Feature (cross-repo readiness, **primary**) | **Scoped** — replaces bundled dataset proposal; blocked until `honeybee-ph>=1.33.35` is published and verified | [`features/epw-derived-preliminary-climate/`](features/epw-derived-preliminary-climate/README.md) → [decision 0004](../context/decisions/0004-no-bundled-licensed-climate-data.md) |
-| `Space.from_room()` default-space factory (upstream from GH) | Feature (cross-repo, **primary**) | **Implementing** — Phase 03 complete; Phase 04 release/GH handoff next | [`features/space-from-room-factory/`](features/space-from-room-factory/README.md) |
+| `Space.from_room()` default-space factory (upstream from GH) | Feature (cross-repo, **primary**) | **Released v1.33.36; GH v1.28.1 pinned** — live meter/non-meter canvas verification remains before archive | [`features/space-from-room-factory/`](features/space-from-room-factory/README.md) |
 | Explicit `PhVentilationSystem` factories | Feature (cross-repo) | **Scoped** — local API fixed; Phase 01 state matrix required before code | [`features/default-ventilation-system-factory/`](features/default-ventilation-system-factory/README.md) |
 | Default dwelling identity across HBJSON round-trips | Bug fix | **Requested** — reproduced in PHX; not implemented | [`refactor/dwelling-default-roundtrip.md`](refactor/dwelling-default-roundtrip.md) |
 | Decouple "Dwelling" from `Room.zone` | Refactor (cross-repo, **primary**) | **Released** in v1.33.30 — downstream install/PHX status remains in companion docs | [`refactor/dwelling-zone-decoupling.md`](refactor/dwelling-zone-decoupling.md) → [decision 0002](../context/decisions/0002-dwelling-identity-not-room-zone.md) |
@@ -70,8 +70,8 @@ re-points its component at it and retires the Rhino-side duplicate.
 
 | Repo | Doc | Role |
 |------|-----|------|
-| `honeybee_ph` | [`features/space-from-room-factory/`](features/space-from-room-factory/PRD.md) | Primary — factory + tests |
-| `honeybee_grasshopper_ph` | `planning/refactor/space-from-room-factory.md` | Wrapper re-point; shrinks `make_spaces/` — blocked on primary release |
+| `honeybee_ph` | [`features/space-from-room-factory/`](features/space-from-room-factory/PRD.md) | Primary — **released v1.33.36**; live GH canvas evidence remains before archive |
+| `honeybee_grasshopper_ph` | `planning/refactor/space-from-room-factory.md` | Wrapper **released v1.28.1** with generated `honeybee-ph>=1.33.36` pin; live canvas check remains |
 
 `epw-derived-preliminary-climate` is owned here and will be implemented here,
 with downstream readiness coordination. This repo owns EPW conversion, provenance,

--- a/planning/features/space-from-room-factory/STATUS.md
+++ b/planning/features/space-from-room-factory/STATUS.md
@@ -1,6 +1,7 @@
 # STATUS — space-from-room-factory
 
-**Status:** Implementing · Phase 03 complete; Phase 04 next · 2026-08-14
+**Status:** Released · Phase 04 handoff substantially complete; live GH canvas
+verification remains · 2026-08-14
 
 - Phase 01 contract suite added: focused failures reproduced only the
   missing `Space.from_room()` API/import before implementation.
@@ -14,9 +15,11 @@
 - Phase 03 full gate: 914 tests pass; aggregate coverage is 79% and clears the
   user-approved 75% repository floor; Black, compatibility parser,
   `git diff --check`, sdist/wheel build, and wheel API inspection pass.
-- Cross-repo: **this repo is primary and ships first.** The GH-side wrapper
-  refactor (`honeybee_grasshopper_ph/planning/refactor/space-from-room-factory.md`)
-  is blocked on this repo's release + pin bump.
+- Primary release: PR #89 merged as `e456ca5`; release workflow 31818498356
+  published `honeybee-ph==1.33.36` from `3371ab2`.
+- Cross-repo handoff: the GH wrapper refactor merged in PR #61 and shipped in
+  `honeybee_grasshopper_ph` v1.28.1. Its generated `requirements.txt` and
+  installer both require `honeybee-ph>=1.33.36`.
 - Key contracts are fixed in `PRD.md`: v1 preserves one floor/volume per
   source floor face, uses the Honeybee Room as `Space.host`, normalizes the
   usual Honeybee `-Z` floor winding only for `+Z` extrusion, and rejects
@@ -28,6 +31,13 @@
 - `docs/nav.yml` already exposes the `space` API module; no method-level nav
   entry is required. The classmethod and model-unit semantics are documented
   in source for autodoc.
-- **Next step:** execute Phase 04 primary release and the blocked Grasshopper
-  wrapper handoff.
-- Blockers: none.
+- Phase 04 headless wrapper evidence covers meter/foot unit conversion, source
+  Room non-mutation, floor area/volume, Room HBJSON round-trip, and IGH error
+  routing. The wrapper no longer performs duplicate default-space assembly;
+  all `make_spaces/` helpers remain because other detailed-space components
+  still import them.
+- **Next step / closeout blocker:** run the released component on meter and
+  non-meter Rhino canvases and record iCFA/HBJSON parity plus the intentional
+  multi-floor volume-count and `Space.host` corrections. No existing repo
+  verification definition was found; headless evidence is not labeled as the
+  live canvas check.

--- a/planning/features/space-from-room-factory/phases/phase-04-release-and-gh-handoff.md
+++ b/planning/features/space-from-room-factory/phases/phase-04-release-and-gh-handoff.md
@@ -32,3 +32,23 @@ and prove behavior parity before retiring duplicate orchestration.
 - No still-imported `make_spaces` helper was removed.
 - Both repo packets/statuses record the release, pin, and verification evidence.
 
+## Evidence — 2026-08-14
+
+- Primary PR #89 merged at `e456ca5`; release workflow 31818498356 succeeded
+  and published `honeybee-ph==1.33.36` from tag/commit `3371ab2`.
+- The release was installed and API-checked in the GH repo `.venv` and
+  `/Users/em/ladybug_tools/python`. Rhino was not running, so no restart was
+  required before the non-GUI checks.
+- GH PR #61 merged at `9d2ae2a`; release workflow 31819524996 succeeded and
+  published `honeybee_grasshopper_ph` v1.28.1 from `062402f`.
+- Generated `requirements.txt` and `hbph_installer.ghx` both require
+  `honeybee-ph>=1.33.36`.
+- The wrapper now owns only Room duplication, one document-unit conversion per
+  run, attachment, and IGH error routing. Import audit confirms every
+  `make_spaces/` helper still has another detailed-space consumer.
+- Headless meter/foot smoke verifies 2.5 m / 8.2020997375 ft heights, source
+  Room non-mutation, 20 model-unit-squared floor and weighted floor area,
+  volume, Room HBJSON round-trip, and no-floor/conversion error routing.
+- Remaining exit check: live meter and non-meter Rhino/Grasshopper definitions,
+  including multi-floor volume count and `Space.host` identity. No existing
+  repo definition exercises this component, so the packet remains active.


### PR DESCRIPTION
## Summary
- record the honeybee-ph 1.33.36 primary release and GH 1.28.1 downstream release
- record the generated downstream minimum pin and headless wrapper evidence
- keep live meter/non-meter Rhino canvas verification explicit before archive

## Verification
- primary release workflow 31818498356 succeeded
- downstream release workflow 31819524996 succeeded
- downstream requirements and installer require honeybee-ph 1.33.36 or newer
- git diff check