### PR TITLE
Fix Codex fsdeploy hook matching

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,14 +1,27 @@
 {
+  "description": "Mirror honeybee-ph package edits into installed local development targets.",
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "^apply_patch$",
         "hooks": [
           {
             "type": "command",
-            "command": "/Users/em/Dropbox/bldgtyp-00/00_PH_Tools/honeybee_ph/.claude/fsdeploy-hook.sh",
-            "timeout": 10,
-            "statusMessage": "Deploying to targets..."
+            "command": "REPO_ROOT=$(git rev-parse --show-toplevel) && /Users/em/.claude/ph-tools-fsdeploy.sh --sync-repo \"$REPO_ROOT\"",
+            "timeout": 30,
+            "statusMessage": "Syncing honeybee-ph edits to installed development targets..."
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "REPO_ROOT=$(git rev-parse --show-toplevel) && /Users/em/.claude/ph-tools-fsdeploy.sh --sync-repo \"$REPO_ROOT\" && printf '%s\\n' '{\"continue\":true,\"suppressOutput\":true}'",
+            "timeout": 30,
+            "statusMessage": "Syncing honeybee-ph to installed development targets..."
           }
         ]
       }


### PR DESCRIPTION
## Summary
- match the Codex apply_patch tool instead of Claude Edit and Write tools
- sync the complete repository packages after each patch
- add a final Stop sync so deletes, renames, and multi-file patches reach installed development targets

## Verification
- hooks.json parses with jq
- shared PH-Tools deploy script synced this repository to 39 installed package targets
- stale-file deletion and honeybee_ph space.py parity passed in Ladybug Tools
- the existing manual-test.ghx remains untracked and untouched