### PR TITLE
feat(site): add EPW-derived preliminary climate

### DIFF
--- a/context/ARCHITECTURE.md
+++ b/context/ARCHITECTURE.md
@@ -40,6 +40,22 @@ Within `honeybee_ph`, `honeybee_energy_ph`, and `honeybee_phhvac`, the `properti
 
 Every model class implements `to_dict()` / `from_dict()` (and usually `duplicate()`). HBJSON is the interchange format for the whole ecosystem, so **backward compatibility is a hard requirement** — see `CODING_STANDARDS.md` §Serialization. `from_dict()` must tolerate HBJSON written by older versions that lack newer keys.
 
+### Climate provenance and readiness
+
+`Climate.provenance` is optional so legacy HBJSON remains byte-shape compatible.
+When present, it records source type, checksum/method metadata, certification
+approval, monthly availability, peak-load availability, and JSON-safe
+assumptions. `Climate.monthly_demand_readiness_issues()` and
+`Climate.peak_load_readiness_issues()` are the canonical downstream gates;
+numeric zero never implies missing data.
+
+`Site.from_epw()` is the supported one-call EPW path. It creates preliminary
+monthly values with blank PHPP library codes and explicit provenance, but no
+PHI/Phius peak-load sets. Downstream PHX conversion must reject that
+monthly-only state with the readiness diagnostic rather than constructing
+zero-filled peak inputs. No weather file or licensed PHI/Phius climate dataset
+is distributed by this repository.
+
 ## Dependencies
 
 Runtime deps are deliberately minimal: `honeybee-core`, `honeybee-energy`, and `PH-units` (unit parsing/conversion). No heavy scientific stack — the code has to load in Rhino.
@@ -69,6 +85,7 @@ merging thermal zones and dropping HVAC systems. See
 
 ## Where the boundaries are
 
-- Export/conversion logic → **PHX**, not here.
+- PHPP/WUFI export logic → **PHX**; the local EPW-to-Site derivation remains a
+  data-model factory and does not export a proprietary format.
 - Grasshopper components → **honeybee_grasshopper_ph**, not here.
 - This repo stays a pure, IronPython-2.7-safe data-model library.

--- a/context/PRD.md
+++ b/context/PRD.md
@@ -21,7 +21,9 @@ Not affiliated with or endorsed by PHI or Phius.
 
 - New PH attributes on Honeybee/Honeybee-Energy objects (spaces, windows, constructions, HVAC, loads, certification thresholds).
 - The object model + `to_dict()`/`from_dict()` HBJSON round-tripping for those attributes.
-- Reference standards data (climates, assemblies, schedules) shipped as JSON.
+- Reference standards data whose terms permit redistribution (assemblies,
+  schedules, and source factors). Licensed PHI/Phius climate datasets are not
+  bundled.
 - Shared utilities those objects need (unit handling via `PH-units`, colors, geometry helpers).
 
 ## 4. Non-goals

--- a/docs/epw-preliminary-climate.md
+++ b/docs/epw-preliminary-climate.md
@@ -1,0 +1,73 @@
+---
+title: EPW preliminary climate
+---
+
+# EPW-derived preliminary climate
+
+`Site.from_epw()` converts a caller-supplied annual EPW file into preliminary
+monthly-demand climate inputs. It reads only the supplied local file; it does
+not search for, download, cache, or redistribute weather data.
+
+```python
+from honeybee_ph.site import Site
+
+site = Site.from_epw(
+    "/path/to/weather.epw",
+    ground_temperature_depth=0.5,
+    ground_reflectance=0.2,
+    diffuse_model="isotropic",
+)
+```
+
+EPW-derived values are not PHI- or Phius-approved certification climate data.
+The returned `Site` therefore has blank PHPP library codes, no peak-load
+climate sets, `is_certification_approved=False`, and
+`peak_load_data_available=False`. Supply approved or specialized peak-load
+climate data separately when a downstream workflow requires it.
+
+PHX conversion currently rejects this monthly-only Site before building an
+export model. Its `ValueError` includes the climate-readiness issue stating
+that approved or specialized peak-load climate data must be supplied
+separately. Adding that data is a deliberate downstream enrichment step; the
+EPW factory never fills peak inputs with zeros.
+
+## Derived fields and units
+
+| Output | Source / method | Unit |
+|---|---|---|
+| Latitude / longitude | EPW location header | decimal degrees |
+| Site and station elevation | EPW location header | m |
+| UTC offset | EPW location header | h |
+| Air temperature | Monthly mean dry-bulb | °C |
+| Dewpoint | Monthly mean dewpoint | °C |
+| Sky temperature | Monthly mean Ladybug `EPW.sky_temperature` | °C |
+| Ground temperature | Selected EPW monthly ground series | °C |
+| Global radiation | Monthly global-horizontal total | kWh/m² |
+| N/E/S/W radiation | Monthly vertical-plane total | kWh/m² |
+| Average wind speed | Annual arithmetic mean | m/s |
+| Summer daily swing | Mean daily dry-bulb range over the warmest three consecutive months | K |
+
+Cardinal radiation uses unobstructed vertical planes at Ladybug azimuths
+0°/90°/180°/270° for north/east/south/west. `ground_reflectance` must be from
+0 through 1. `diffuse_model` is either `"isotropic"` or `"anisotropic"`.
+These choices and the azimuth mapping are retained in climate provenance. No
+shading or site-obstruction model is implied.
+
+## Ground-temperature selection
+
+Ground temperature comes only from the EPW ground-temperature header. When the
+file contains one series, omitting `ground_temperature_depth` selects it. When
+the file contains multiple series, pass an available depth in meters. A file
+with no ground series, or a requested depth that is unavailable, raises a
+targeted `ValueError`; air temperature and zero are never substituted.
+
+## Readiness and provenance
+
+A successful conversion sets `monthly_data_available=True`, and
+`site.climate.is_monthly_demand_ready` is true only when every required scalar
+and all 12 monthly values are finite. Peak-load readiness remains false.
+
+`site.climate.provenance` records the absolute source path, SHA-256 checksum,
+conversion method/version, selected ground depth, radiation assumptions, and
+availability flags. Provenance survives JSON/HBJSON round-trips and
+duplication. The caller remains responsible for the right to process the EPW.

--- a/docs/nav.yml
+++ b/docs/nav.yml
@@ -1,6 +1,7 @@
 nav:
   - Getting Started:
     - Overview: getting-started.md
+    - EPW preliminary climate: epw-preliminary-climate.md
   - Packages:
     - Overview: packages.md
   - API Reference:

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -17,7 +17,8 @@ The core Passive House data model. Adds PH-specific elements to Honeybee includi
 - **Spaces** — interior floor areas with iCFA/TFA weighting factors
 - **Building segments** — PH certification boundaries and climate data
 - **Certification** — PHI and Phius certification thresholds and settings
-- **Site** — location, climate, and shading data
+- **Site** — location, climate, and shading data, including preliminary monthly
+  climate derived from a caller-supplied EPW
 
 [PyPI](https://pypi.org/project/honeybee-ph/) |
 [Source](https://github.com/PH-Tools/honeybee_ph/tree/main/honeybee_ph)

--- a/honeybee_ph/_epw.py
+++ b/honeybee_ph/_epw.py
@@ -1,0 +1,316 @@
+# -*- coding: utf-8 -*-
+# -*- Python Version: 2.7 -*-
+
+"""Internal conversion of caller-supplied EPW weather data."""
+
+import hashlib
+import os
+
+try:
+    from typing import Any, Dict, List, Optional, Tuple
+except ImportError:  # pragma: no cover - IronPython 2.7
+    pass
+
+from ladybug.epw import EPW
+from ladybug.skymodel import calc_horizontal_infrared
+
+from honeybee_ph.site import ClimateProvenance, _is_finite_real
+
+
+class EPWConversionResult(object):
+    """Internal values and accumulated issues from an EPW conversion."""
+
+    def __init__(self, file_path):
+        # type: (str) -> None
+        self.file_path = file_path
+        self.location_name = None  # type: Optional[str]
+        self.latitude = None  # type: Optional[float]
+        self.longitude = None  # type: Optional[float]
+        self.elevation = None  # type: Optional[float]
+        self.utc_offset = None  # type: Optional[float]
+        self.monthly_air_temperatures = None  # type: Optional[List[float]]
+        self.monthly_dewpoint_temperatures = None  # type: Optional[List[float]]
+        self.monthly_sky_temperatures = None  # type: Optional[List[float]]
+        self.average_wind_speed = None  # type: Optional[float]
+        self.summer_daily_temperature_swing = None  # type: Optional[float]
+        self.issues = []  # type: List[str]
+        self.provenance = ClimateProvenance(
+            source_type="epw_derived",
+            source_uri=file_path,
+            conversion_method="ladybug_epw_preliminary_monthly",
+            conversion_method_version="1",
+            is_certification_approved=False,
+            monthly_data_available=False,
+            peak_load_data_available=False,
+            assumptions={
+                "summer_daily_temperature_swing": (
+                    "mean daily dry-bulb range over the warmest three consecutive calendar months"
+                ),
+                "sky_temperature": (
+                    "ladybug EPW.sky_temperature with horizontal-infrared fallback from opaque sky cover"
+                ),
+            },
+        )
+
+    @property
+    def source_checksum(self):
+        # type: () -> Optional[str]
+        """SHA-256 checksum for the exact EPW snapshot used by Ladybug."""
+        return self.provenance.source_checksum
+
+
+def _issue(file_path, field_name, message):
+    # type: (str, str, str) -> str
+    return "{}: {}: {}".format(file_path, field_name, message)
+
+
+def _read_source(result):
+    # type: (EPWConversionResult) -> Optional[str]
+    try:
+        with open(result.file_path, "rb") as epw_file:
+            source = epw_file.read()
+    except (IOError, OSError) as error:
+        result.issues.append(_issue(result.file_path, "file", "unable to read EPW ({})".format(error)))
+        return None
+
+    result.provenance.source_checksum = hashlib.sha256(source).hexdigest()
+    try:
+        text = source.decode("utf-8-sig")
+    except UnicodeDecodeError as error:
+        result.issues.append(_issue(result.file_path, "file", "EPW is not valid UTF-8 text ({})".format(error)))
+        return None
+    return text
+
+
+def _header_float_issue(file_path, field_name, raw_value, minimum=None, maximum=None):
+    # type: (str, str, str, Optional[float], Optional[float]) -> Tuple[Optional[float], Optional[str]]
+    try:
+        value = float(raw_value)
+    except (TypeError, ValueError):
+        return None, _issue(file_path, field_name, "expected a finite number; observed {!r}.".format(raw_value))
+    if not _is_finite_real(value):
+        return None, _issue(file_path, field_name, "expected a finite number; observed {!r}.".format(raw_value))
+    if (minimum is not None and value < minimum) or (maximum is not None and value > maximum):
+        return None, _issue(
+            file_path,
+            field_name,
+            "expected a value from {} through {}; observed {!r}.".format(minimum, maximum, raw_value),
+        )
+    return value, None
+
+
+def _validate_header(result, lines):
+    # type: (EPWConversionResult, List[str]) -> bool
+    if len(lines) < 9:
+        result.issues.append(
+            _issue(
+                result.file_path,
+                "header",
+                "expected at least 8 EPW header lines and hourly data; got {} total lines.".format(len(lines)),
+            )
+        )
+        return False
+
+    location_fields = lines[0].split(",")
+    if len(location_fields) < 10 or location_fields[0].strip().upper() != "LOCATION":
+        result.issues.append(_issue(result.file_path, "location", "expected a 10-field EPW LOCATION header."))
+        return False
+
+    location_values = (
+        ("location.latitude", location_fields[6], -90.0, 90.0),
+        ("location.longitude", location_fields[7], -180.0, 180.0),
+        ("location.utc_offset", location_fields[8], -12.0, 14.0),
+        ("location.elevation", location_fields[9], -1000.0, 10000.0),
+    )
+    for field_name, raw_value, minimum, maximum in location_values:
+        _, issue = _header_float_issue(result.file_path, field_name, raw_value, minimum, maximum)
+        if issue:
+            result.issues.append(issue)
+    if result.issues:
+        return False
+
+    leap_fields = lines[4].split(",")
+    leap_value = leap_fields[1].strip() if len(leap_fields) > 1 else ""
+    if leap_value not in ("Yes", "No"):
+        result.issues.append(
+            _issue(result.file_path, "header.is_leap_year", "expected 'Yes' or 'No'; observed {!r}.".format(leap_value))
+        )
+        return False
+    expected_hours = 8784 if leap_value == "Yes" else 8760
+    observed_hours = len([line for line in lines[8:] if line.strip()])
+    if observed_hours != expected_hours:
+        year_type = "leap" if leap_value == "Yes" else "non-leap"
+        result.issues.append(
+            _issue(
+                result.file_path,
+                "hourly_data",
+                "expected {} hourly rows for a {} year; got {}.".format(expected_hours, year_type, observed_hours),
+            )
+        )
+        return False
+    return True
+
+
+def _preflight_horizontal_infrared(result, lines):
+    # type: (EPWConversionResult, List[str]) -> bool
+    for index, line in enumerate(lines[8:]):
+        fields = line.split(",")
+        if len(fields) <= 12:
+            return True
+        try:
+            value = float(fields[12])
+        except ValueError:
+            return True
+        if not _is_finite_real(value):
+            result.issues.append(
+                _issue(
+                    result.file_path,
+                    "horizontal_infrared_radiation_intensity hour {}".format(index + 1),
+                    "observed {!r}.".format(value),
+                )
+            )
+    return not result.issues
+
+
+def _validated_series(file_path, field_name, values, missing_value, minimum, maximum):
+    # type: (str, str, List[float], float, float, float) -> Tuple[Optional[List[float]], List[str]]
+    issues = []
+    for index, value in enumerate(values):
+        hour = index + 1
+        if not _is_finite_real(value):
+            issues.append(_issue(file_path, "{} hour {}".format(field_name, hour), "observed {!r}.".format(value)))
+        elif value == missing_value:
+            issues.append(
+                _issue(
+                    file_path,
+                    "{} hour {}".format(field_name, hour),
+                    "observed missing sentinel {!r}.".format(missing_value),
+                )
+            )
+        elif value < minimum or value > maximum:
+            issues.append(
+                _issue(
+                    file_path,
+                    "{} hour {}".format(field_name, hour),
+                    "expected {} through {}; observed {!r}.".format(minimum, maximum, value),
+                )
+            )
+    return (None if issues else list(values)), issues
+
+
+def _monthly_means(collection):
+    # type: (Any) -> List[float]
+    monthly_values = [[] for _ in range(12)]
+    for value, dt in zip(collection.values, collection.datetimes):
+        monthly_values[dt.month - 1].append(value)
+    return [sum(values) / len(values) for values in monthly_values]
+
+
+def _summer_daily_swing(values, datetimes, monthly_means):
+    # type: (List[float], List[Any], List[float]) -> Tuple[float, List[int]]
+    start_month = max(
+        range(12),
+        key=lambda index: sum(monthly_means[(index + offset) % 12] for offset in range(3)),
+    )
+    warmest_months = [((start_month + offset) % 12) + 1 for offset in range(3)]
+    daily_values = {}  # type: Dict[Tuple[int, int], List[float]]
+    for value, dt in zip(values, datetimes):
+        if dt.month in warmest_months:
+            daily_values.setdefault((dt.month, dt.day), []).append(value)
+    daily_ranges = [max(day_values) - min(day_values) for day_values in daily_values.values()]
+    return sum(daily_ranges) / len(daily_ranges), warmest_months
+
+
+def _resolved_horizontal_infrared(result, epw, dry_bulb, dewpoint):
+    # type: (EPWConversionResult, EPW, Optional[List[float]], Optional[List[float]]) -> Optional[List[float]]
+    horizontal_ir = list(epw.horizontal_infrared_radiation_intensity.values)
+    opaque_sky = list(epw.opaque_sky_cover.values)
+    resolved = []
+    issues = []
+    for index, value in enumerate(horizontal_ir):
+        if value >= 9999:
+            sky_cover = opaque_sky[index]
+            if dry_bulb is None or dewpoint is None:
+                continue
+            if not _is_finite_real(sky_cover) or sky_cover < 0 or sky_cover > 10:
+                issues.append(
+                    _issue(
+                        result.file_path,
+                        "opaque_sky_cover hour {}".format(index + 1),
+                        "required for horizontal-infrared fallback; observed {!r}.".format(sky_cover),
+                    )
+                )
+            else:
+                resolved.append(calc_horizontal_infrared(sky_cover, dry_bulb[index], dewpoint[index]))
+        elif value < 0:
+            issues.append(
+                _issue(
+                    result.file_path,
+                    "horizontal_infrared_radiation_intensity hour {}".format(index + 1),
+                    "expected a non-negative value; observed {!r}.".format(value),
+                )
+            )
+        else:
+            resolved.append(value)
+    result.issues.extend(issues)
+    return None if issues or len(resolved) != len(horizontal_ir) else resolved
+
+
+def convert_epw(file_path):
+    # type: (str) -> EPWConversionResult
+    """Convert EPW location and temperature fields into an internal result."""
+    path = os.path.abspath(str(file_path))
+    result = EPWConversionResult(path)
+    source_text = _read_source(result)
+    if source_text is None:
+        return result
+    lines = source_text.splitlines()
+    if not _validate_header(result, lines):
+        return result
+    if not _preflight_horizontal_infrared(result, lines):
+        return result
+
+    try:
+        epw = EPW.from_file_string(source_text if source_text.endswith("\n") else source_text + "\n")
+        location = epw.location
+        dry_collection = epw.dry_bulb_temperature
+        dewpoint_collection = epw.dew_point_temperature
+        wind_collection = epw.wind_speed
+    except Exception as error:
+        result.issues.append(_issue(path, "epw", "Ladybug failed to parse the file ({})".format(error)))
+        return result
+
+    result.location_name = location.city
+    result.latitude = location.latitude
+    result.longitude = location.longitude
+    result.elevation = location.elevation
+    result.utc_offset = location.time_zone
+    result.provenance.source_name = location.city
+
+    dry_bulb, dry_issues = _validated_series(
+        path, "dry_bulb_temperature", list(dry_collection.values), 99.9, -70.0, 70.0
+    )
+    dewpoint, dewpoint_issues = _validated_series(
+        path, "dew_point_temperature", list(dewpoint_collection.values), 99.9, -70.0, 70.0
+    )
+    wind_speed, wind_issues = _validated_series(path, "wind_speed", list(wind_collection.values), 999, 0.0, 40.0)
+    result.issues.extend(dry_issues)
+    result.issues.extend(dewpoint_issues)
+    result.issues.extend(wind_issues)
+
+    if dry_bulb is not None:
+        result.monthly_air_temperatures = _monthly_means(dry_collection)
+        result.summer_daily_temperature_swing, warmest_months = _summer_daily_swing(
+            dry_bulb, list(dry_collection.datetimes), result.monthly_air_temperatures
+        )
+        result.provenance.assumptions["warmest_consecutive_months"] = warmest_months
+    if dewpoint is not None:
+        result.monthly_dewpoint_temperatures = _monthly_means(dewpoint_collection)
+    if wind_speed is not None:
+        result.average_wind_speed = wind_collection.average
+
+    horizontal_ir = _resolved_horizontal_infrared(result, epw, dry_bulb, dewpoint)
+    if horizontal_ir is not None:
+        epw.horizontal_infrared_radiation_intensity.values = horizontal_ir
+        result.monthly_sky_temperatures = _monthly_means(epw.sky_temperature)
+    return result

--- a/honeybee_ph/_epw.py
+++ b/honeybee_ph/_epw.py
@@ -13,8 +13,9 @@ except ImportError:  # pragma: no cover - IronPython 2.7
 
 from ladybug.epw import EPW
 from ladybug.skymodel import calc_horizontal_infrared
+from ladybug.wea import Wea
 
-from honeybee_ph.site import ClimateProvenance, _is_finite_real
+from honeybee_ph.site import ClimateProvenance, Climate_MonthlyValueSet, _is_finite_real
 
 
 class EPWConversionResult(object):
@@ -31,6 +32,13 @@ class EPWConversionResult(object):
         self.monthly_air_temperatures = None  # type: Optional[List[float]]
         self.monthly_dewpoint_temperatures = None  # type: Optional[List[float]]
         self.monthly_sky_temperatures = None  # type: Optional[List[float]]
+        self.monthly_ground_temperatures = None  # type: Optional[List[float]]
+        self.ground_temperature_depth = None  # type: Optional[float]
+        self.monthly_north_radiation = None  # type: Optional[List[float]]
+        self.monthly_east_radiation = None  # type: Optional[List[float]]
+        self.monthly_south_radiation = None  # type: Optional[List[float]]
+        self.monthly_west_radiation = None  # type: Optional[List[float]]
+        self.monthly_global_radiation = None  # type: Optional[List[float]]
         self.average_wind_speed = None  # type: Optional[float]
         self.summer_daily_temperature_swing = None  # type: Optional[float]
         self.issues = []  # type: List[str]
@@ -122,11 +130,12 @@ def _validate_header(result, lines):
         ("location.utc_offset", location_fields[8], -12.0, 14.0),
         ("location.elevation", location_fields[9], -1000.0, 10000.0),
     )
+    issue_count = len(result.issues)
     for field_name, raw_value, minimum, maximum in location_values:
         _, issue = _header_float_issue(result.file_path, field_name, raw_value, minimum, maximum)
         if issue:
             result.issues.append(issue)
-    if result.issues:
+    if len(result.issues) != issue_count:
         return False
 
     leap_fields = lines[4].split(",")
@@ -151,25 +160,69 @@ def _validate_header(result, lines):
     return True
 
 
-def _preflight_horizontal_infrared(result, lines):
+def _preflight_integer_fields(result, lines):
     # type: (EPWConversionResult, List[str]) -> bool
+    issue_count = len(result.issues)
+    integer_fields = (
+        (12, "horizontal_infrared_radiation_intensity"),
+        (13, "global_horizontal_radiation"),
+        (14, "direct_normal_radiation"),
+        (15, "diffuse_horizontal_radiation"),
+    )
     for index, line in enumerate(lines[8:]):
         fields = line.split(",")
-        if len(fields) <= 12:
-            return True
-        try:
-            value = float(fields[12])
-        except ValueError:
-            return True
-        if not _is_finite_real(value):
-            result.issues.append(
-                _issue(
-                    result.file_path,
-                    "horizontal_infrared_radiation_intensity hour {}".format(index + 1),
-                    "observed {!r}.".format(value),
+        for field_index, field_name in integer_fields:
+            if len(fields) <= field_index:
+                continue
+            try:
+                value = float(fields[field_index])
+            except ValueError:
+                continue
+            if not _is_finite_real(value):
+                result.issues.append(
+                    _issue(
+                        result.file_path,
+                        "{} hour {}".format(field_name, index + 1),
+                        "observed {!r}.".format(value),
+                    )
                 )
+    return len(result.issues) == issue_count
+
+
+def _validate_options(result, ground_temperature_depth, ground_reflectance, diffuse_model):
+    # type: (EPWConversionResult, Optional[float], float, str) -> None
+    if not _is_finite_real(ground_reflectance) or not 0 <= ground_reflectance <= 1:
+        result.issues.append(
+            _issue(
+                result.file_path,
+                "ground_reflectance",
+                "expected a finite value from 0 through 1; observed {!r}.".format(ground_reflectance),
             )
-    return not result.issues
+        )
+    else:
+        result.provenance.assumptions["ground_reflectance"] = ground_reflectance
+    if diffuse_model not in ("isotropic", "anisotropic"):
+        result.issues.append(
+            _issue(
+                result.file_path,
+                "diffuse_model",
+                "expected 'isotropic' or 'anisotropic'; observed {!r}.".format(diffuse_model),
+            )
+        )
+    else:
+        result.provenance.assumptions["diffuse_model"] = diffuse_model
+    if ground_temperature_depth is not None and (
+        not _is_finite_real(ground_temperature_depth) or ground_temperature_depth < 0
+    ):
+        result.issues.append(
+            _issue(
+                result.file_path,
+                "ground_temperature_depth",
+                "expected None or a finite non-negative depth in meters; observed {!r}.".format(
+                    ground_temperature_depth
+                ),
+            )
+        )
 
 
 def _validated_series(file_path, field_name, values, missing_value, minimum, maximum):
@@ -195,15 +248,30 @@ def _validated_series(file_path, field_name, values, missing_value, minimum, max
                     "expected {} through {}; observed {!r}.".format(minimum, maximum, value),
                 )
             )
-    return (None if issues else list(values)), issues
+    return (None if issues else values), issues
+
+
+def _monthly_sums_and_counts(collection):
+    # type: (Any) -> Tuple[List[float], List[int]]
+    monthly_sums = [0.0] * 12
+    monthly_counts = [0] * 12
+    for value, dt in zip(collection.values, collection.datetimes):
+        month_index = dt.month - 1
+        monthly_sums[month_index] += value
+        monthly_counts[month_index] += 1
+    return monthly_sums, monthly_counts
 
 
 def _monthly_means(collection):
     # type: (Any) -> List[float]
-    monthly_values = [[] for _ in range(12)]
-    for value, dt in zip(collection.values, collection.datetimes):
-        monthly_values[dt.month - 1].append(value)
-    return [sum(values) / len(values) for values in monthly_values]
+    monthly_sums, monthly_counts = _monthly_sums_and_counts(collection)
+    return [total / count for total, count in zip(monthly_sums, monthly_counts)]
+
+
+def _monthly_totals_kwh(collection):
+    # type: (Any) -> List[float]
+    monthly_sums, _ = _monthly_sums_and_counts(collection)
+    return [total / 1000.0 for total in monthly_sums]
 
 
 def _summer_daily_swing(values, datetimes, monthly_means):
@@ -256,18 +324,105 @@ def _resolved_horizontal_infrared(result, epw, dry_bulb, dewpoint):
     return None if issues or len(resolved) != len(horizontal_ir) else resolved
 
 
-def convert_epw(file_path):
-    # type: (str) -> EPWConversionResult
-    """Convert EPW location and temperature fields into an internal result."""
+def _select_ground_temperature(result, epw, requested_depth):
+    # type: (EPWConversionResult, EPW, Optional[float]) -> None
+    ground_series = epw.monthly_ground_temperature
+    available_depths = sorted(ground_series.keys())
+    if not available_depths:
+        result.issues.append(
+            _issue(result.file_path, "ground_temperature", "EPW header contains no monthly ground-temperature series.")
+        )
+        return
+    if requested_depth is None:
+        if len(available_depths) != 1:
+            result.issues.append(
+                _issue(
+                    result.file_path,
+                    "ground_temperature_depth",
+                    "EPW header has multiple series; choose one of {} m.".format(available_depths),
+                )
+            )
+            return
+        selected_depth = available_depths[0]
+    elif requested_depth not in ground_series:
+        result.issues.append(
+            _issue(
+                result.file_path,
+                "ground_temperature_depth",
+                "requested {} m; available depths are {} m.".format(requested_depth, available_depths),
+            )
+        )
+        return
+    else:
+        selected_depth = requested_depth
+
+    values = list(ground_series[selected_depth].values)
+    if len(values) != 12:
+        result.issues.append(
+            _issue(
+                result.file_path,
+                "ground_temperature depth {} m".format(selected_depth),
+                "expected 12 monthly values; got {}.".format(len(values)),
+            )
+        )
+        return
+    ground_issues = []
+    for month_name, value in zip(Climate_MonthlyValueSet.months, values):
+        if not _is_finite_real(value) or value < -70 or value > 70:
+            ground_issues.append(
+                _issue(
+                    result.file_path,
+                    "ground_temperature depth {} m {}".format(selected_depth, month_name),
+                    "expected a finite value from -70 through 70 C; observed {!r}.".format(value),
+                )
+            )
+    result.issues.extend(ground_issues)
+    if not ground_issues:
+        result.ground_temperature_depth = selected_depth
+        result.monthly_ground_temperatures = values
+        result.provenance.assumptions["ground_temperature_depth_m"] = selected_depth
+
+
+def _set_directional_radiation(result, epw, direct_normal, diffuse_horizontal, ground_reflectance, diffuse_model):
+    # type: (EPWConversionResult, EPW, Optional[List[float]], Optional[List[float]], float, str) -> None
+    if direct_normal is None or diffuse_horizontal is None:
+        return
+    wea = Wea(epw.location, epw.direct_normal_radiation, epw.diffuse_horizontal_radiation)
+    isotropic = diffuse_model == "isotropic"
+    orientations = (
+        ("north", "monthly_north_radiation", 0),
+        ("east", "monthly_east_radiation", 90),
+        ("south", "monthly_south_radiation", 180),
+        ("west", "monthly_west_radiation", 270),
+    )
+    for _, field_name, azimuth in orientations:
+        total_irradiance = wea.directional_irradiance(
+            altitude=0,
+            azimuth=azimuth,
+            ground_reflectance=ground_reflectance,
+            isotropic=isotropic,
+        )[0]
+        setattr(result, field_name, _monthly_totals_kwh(total_irradiance))
+    result.provenance.assumptions["vertical_plane_azimuths_degrees"] = {
+        name: azimuth for name, _, azimuth in orientations
+    }
+
+
+def convert_epw(file_path, ground_temperature_depth=None, ground_reflectance=0.2, diffuse_model="isotropic"):
+    # type: (str, Optional[float], float, str) -> EPWConversionResult
+    """Convert EPW monthly-demand fields into an internal result."""
     path = os.path.abspath(str(file_path))
     result = EPWConversionResult(path)
+    _validate_options(result, ground_temperature_depth, ground_reflectance, diffuse_model)
+    if result.issues:
+        return result
     source_text = _read_source(result)
     if source_text is None:
         return result
     lines = source_text.splitlines()
     if not _validate_header(result, lines):
         return result
-    if not _preflight_horizontal_infrared(result, lines):
+    if not _preflight_integer_fields(result, lines):
         return result
 
     try:
@@ -276,6 +431,9 @@ def convert_epw(file_path):
         dry_collection = epw.dry_bulb_temperature
         dewpoint_collection = epw.dew_point_temperature
         wind_collection = epw.wind_speed
+        global_collection = epw.global_horizontal_radiation
+        direct_collection = epw.direct_normal_radiation
+        diffuse_collection = epw.diffuse_horizontal_radiation
     except Exception as error:
         result.issues.append(_issue(path, "epw", "Ladybug failed to parse the file ({})".format(error)))
         return result
@@ -294,9 +452,21 @@ def convert_epw(file_path):
         path, "dew_point_temperature", list(dewpoint_collection.values), 99.9, -70.0, 70.0
     )
     wind_speed, wind_issues = _validated_series(path, "wind_speed", list(wind_collection.values), 999, 0.0, 40.0)
+    global_horizontal, global_issues = _validated_series(
+        path, "global_horizontal_radiation", list(global_collection.values), 9999, 0.0, 9998.0
+    )
+    direct_normal, direct_issues = _validated_series(
+        path, "direct_normal_radiation", list(direct_collection.values), 9999, 0.0, 9998.0
+    )
+    diffuse_horizontal, diffuse_issues = _validated_series(
+        path, "diffuse_horizontal_radiation", list(diffuse_collection.values), 9999, 0.0, 9998.0
+    )
     result.issues.extend(dry_issues)
     result.issues.extend(dewpoint_issues)
     result.issues.extend(wind_issues)
+    result.issues.extend(global_issues)
+    result.issues.extend(direct_issues)
+    result.issues.extend(diffuse_issues)
 
     if dry_bulb is not None:
         result.monthly_air_temperatures = _monthly_means(dry_collection)
@@ -308,9 +478,34 @@ def convert_epw(file_path):
         result.monthly_dewpoint_temperatures = _monthly_means(dewpoint_collection)
     if wind_speed is not None:
         result.average_wind_speed = wind_collection.average
+    if global_horizontal is not None:
+        result.monthly_global_radiation = _monthly_totals_kwh(global_collection)
 
     horizontal_ir = _resolved_horizontal_infrared(result, epw, dry_bulb, dewpoint)
     if horizontal_ir is not None:
         epw.horizontal_infrared_radiation_intensity.values = horizontal_ir
         result.monthly_sky_temperatures = _monthly_means(epw.sky_temperature)
+    _set_directional_radiation(
+        result,
+        epw,
+        direct_normal,
+        diffuse_horizontal,
+        ground_reflectance,
+        diffuse_model,
+    )
+    _select_ground_temperature(result, epw, ground_temperature_depth)
+    required_monthly_values = (
+        result.monthly_air_temperatures,
+        result.monthly_dewpoint_temperatures,
+        result.monthly_sky_temperatures,
+        result.monthly_ground_temperatures,
+        result.monthly_north_radiation,
+        result.monthly_east_radiation,
+        result.monthly_south_radiation,
+        result.monthly_west_radiation,
+        result.monthly_global_radiation,
+    )
+    result.provenance.monthly_data_available = not result.issues and all(
+        values is not None for values in required_monthly_values
+    )
     return result

--- a/honeybee_ph/site.py
+++ b/honeybee_ph/site.py
@@ -22,11 +22,14 @@ from honeybee_ph import _base
 
 def _finite_value_issue(field_name, value):
     # type: (str, Any) -> Optional[str]
-    if isinstance(value, bool) or not isinstance(value, Real):
-        return "{}: expected a finite numeric value; got {!r}.".format(field_name, value)
-    if math.isnan(value) or math.isinf(value):
+    if not _is_finite_real(value):
         return "{}: expected a finite numeric value; got {!r}.".format(field_name, value)
     return None
+
+
+def _is_finite_real(value):
+    # type: (Any) -> bool
+    return not isinstance(value, bool) and isinstance(value, Real) and not math.isnan(value) and not math.isinf(value)
 
 
 class Climate_MonthlyValueSet(_base._Base):

--- a/honeybee_ph/site.py
+++ b/honeybee_ph/site.py
@@ -918,7 +918,8 @@ class Location(_base._Base):
         latitude (float): Site latitude in decimal degrees. Default: 40.6.
         longitude (float): Site longitude in decimal degrees. Default: -73.8.
         site_elevation (Optional[float]): Site elevation in meters above sea level.
-        climate_zone (int): ASHRAE climate zone number. Default: 1.
+        climate_zone (Optional[int]): ASHRAE climate zone number, or None when
+            the source does not supply one. Default: 1.
         hours_from_UTC (int): Time zone offset from UTC in hours. Default: -4.
     """
 
@@ -930,7 +931,7 @@ class Location(_base._Base):
         climate_zone=1,
         hours_from_UTC=-4,
     ):
-        # type: (float, float, Optional[float], int, int) -> None
+        # type: (float, float, Optional[float], Optional[int], int) -> None
         super(Location, self).__init__()
         self.latitude = latitude
         self.longitude = longitude
@@ -1085,6 +1086,80 @@ class Site(_base._Base):
         self.location = _location if _location is not None else Location()
         self.climate = _climate if _climate is not None else Climate()
         self.phpp_library_codes = _phpp_library_codes if _phpp_library_codes is not None else PHPPCodes()
+
+    @classmethod
+    def from_epw(cls, file_path, ground_temperature_depth=None, ground_reflectance=0.2, diffuse_model="isotropic"):
+        # type: (str, Optional[float], float, str) -> Site
+        """Create a preliminary monthly-demand Site from a caller-supplied EPW.
+
+        EPW-derived values are not PHI/Phius certification climate data. The
+        returned Site has blank PHPP library codes and no peak-load climate.
+
+        Arguments:
+        ----------
+            * file_path (str): Path to a local annual EPW file.
+            * ground_temperature_depth (Optional[float]): EPW ground-series
+                depth in meters. May be omitted only when exactly one series
+                is available.
+            * ground_reflectance (float): Finite directional-radiation ground
+                reflectance from 0 through 1. Default: 0.2.
+            * diffuse_model (str): ``"isotropic"`` or ``"anisotropic"``.
+
+        Returns:
+        --------
+            * Site: A fresh, monthly-demand-ready preliminary Site.
+
+        Raises:
+        -------
+            * ValueError: If options or required EPW source data are invalid.
+                All independently detected conversion issues are included.
+        """
+        from honeybee_ph._epw import convert_epw
+
+        result = convert_epw(
+            file_path,
+            ground_temperature_depth=ground_temperature_depth,
+            ground_reflectance=ground_reflectance,
+            diffuse_model=diffuse_model,
+        )
+        if result.issues:
+            raise ValueError("EPW conversion failed:\n- {}".format("\n- ".join(result.issues)))
+
+        location = Location(
+            latitude=result.latitude,
+            longitude=result.longitude,
+            site_elevation=result.elevation,
+            climate_zone=None,
+            hours_from_UTC=result.utc_offset,
+        )
+        location.display_name = result.location_name
+
+        monthly_temps = Climate_MonthlyTempCollection(
+            Climate_MonthlyValueSet(result.monthly_air_temperatures),
+            Climate_MonthlyValueSet(result.monthly_dewpoint_temperatures),
+            Climate_MonthlyValueSet(result.monthly_sky_temperatures),
+            Climate_MonthlyValueSet(result.monthly_ground_temperatures),
+        )
+        monthly_radiation = Climate_MonthlyRadiationCollection(
+            Climate_MonthlyValueSet(result.monthly_north_radiation),
+            Climate_MonthlyValueSet(result.monthly_east_radiation),
+            Climate_MonthlyValueSet(result.monthly_south_radiation),
+            Climate_MonthlyValueSet(result.monthly_west_radiation),
+            Climate_MonthlyValueSet(result.monthly_global_radiation),
+        )
+        climate = Climate(
+            _display_name=result.location_name,
+            _station_elevation=result.elevation,
+            _daily_temp_swing=result.summer_daily_temperature_swing,
+            _average_wind_speed=result.average_wind_speed,
+            _monthly_temps=monthly_temps,
+            _monthly_radiation=monthly_radiation,
+            _peak_loads=None,
+            _provenance=result.provenance,
+        )
+        obj = cls(location, climate, PHPPCodes.blank())
+        obj.display_name = result.location_name
+        return obj
 
     def to_dict(self):
         # type: () -> Dict[str, Any]

--- a/honeybee_ph/site.py
+++ b/honeybee_ph/site.py
@@ -3,7 +3,9 @@
 
 """Passive-House Style Monthly Climate Data"""
 
-from copy import copy
+import math
+from copy import copy, deepcopy
+from numbers import Real
 
 try:
     from itertools import izip as zip  # type: ignore
@@ -16,6 +18,15 @@ except ImportError:
     pass  # IronPython 2.7
 
 from honeybee_ph import _base
+
+
+def _finite_value_issue(field_name, value):
+    # type: (str, Any) -> Optional[str]
+    if isinstance(value, bool) or not isinstance(value, Real):
+        return "{}: expected a finite numeric value; got {!r}.".format(field_name, value)
+    if math.isnan(value) or math.isinf(value):
+        return "{}: expected a finite numeric value; got {!r}.".format(field_name, value)
+    return None
 
 
 class Climate_MonthlyValueSet(_base._Base):
@@ -546,6 +557,142 @@ class Climate_Ground(_base._Base):
         return obj
 
 
+class ClimateProvenance(_base._Base):
+    """Source identity, conversion method, and availability for climate data.
+
+    Availability flags describe whether source data is present; they do not
+    infer completeness from numeric values, since zero is a valid climate value.
+
+    Attributes:
+        source_type (str): Source category. One of ``legacy_unknown``,
+            ``phi_approved``, ``phius_approved``, ``epw_derived``, or
+            ``user_defined``.
+        source_name (Optional[str]): Human-readable source name.
+        source_uri (Optional[str]): Source file path or URI.
+        source_version (Optional[str]): Version of the source data.
+        source_checksum (Optional[str]): SHA-256 checksum for a file source.
+        conversion_method (Optional[str]): Algorithm used to convert the source.
+        conversion_method_version (Optional[str]): Version of the conversion method.
+        is_certification_approved (Optional[bool]): Whether the source is approved
+            for certification; ``None`` means unknown.
+        monthly_data_available (Optional[bool]): Whether monthly-demand data is available.
+        peak_load_data_available (Optional[bool]): Whether peak-load data is available.
+        assumptions (Dict): JSON-safe conversion assumptions.
+    """
+
+    SOURCE_TYPES = (
+        "legacy_unknown",
+        "phi_approved",
+        "phius_approved",
+        "epw_derived",
+        "user_defined",
+    )
+
+    def __init__(
+        self,
+        source_type="legacy_unknown",
+        source_name=None,
+        source_uri=None,
+        source_version=None,
+        source_checksum=None,
+        conversion_method=None,
+        conversion_method_version=None,
+        is_certification_approved=None,
+        monthly_data_available=None,
+        peak_load_data_available=None,
+        assumptions=None,
+    ):
+        # type: (str, Optional[str], Optional[str], Optional[str], Optional[str], Optional[str], Optional[str], Optional[bool], Optional[bool], Optional[bool], Optional[Dict]) -> None
+        super(ClimateProvenance, self).__init__()
+        if source_type not in self.SOURCE_TYPES:
+            raise ValueError(
+                "source_type must be one of {}. Got: {!r}.".format(", ".join(self.SOURCE_TYPES), source_type)
+            )
+        for field_name, value in (
+            ("is_certification_approved", is_certification_approved),
+            ("monthly_data_available", monthly_data_available),
+            ("peak_load_data_available", peak_load_data_available),
+        ):
+            if value is not None and not isinstance(value, bool):
+                raise ValueError("{} must be True, False, or None. Got: {!r}.".format(field_name, value))
+        if assumptions is not None and not isinstance(assumptions, dict):
+            raise ValueError("assumptions must be a dict or None. Got: {!r}.".format(assumptions))
+
+        self.source_type = source_type
+        self.source_name = source_name
+        self.source_uri = source_uri
+        self.source_version = source_version
+        self.source_checksum = source_checksum
+        self.conversion_method = conversion_method
+        self.conversion_method_version = conversion_method_version
+        self.is_certification_approved = is_certification_approved
+        self.monthly_data_available = monthly_data_available
+        self.peak_load_data_available = peak_load_data_available
+        self.assumptions = assumptions if assumptions is not None else {}
+
+    def to_dict(self):
+        # type: () -> Dict[str, Any]
+        return {
+            "display_name": self.display_name,
+            "identifier": self.identifier,
+            "user_data": copy(self.user_data),
+            "source_type": self.source_type,
+            "source_name": self.source_name,
+            "source_uri": self.source_uri,
+            "source_version": self.source_version,
+            "source_checksum": self.source_checksum,
+            "conversion_method": self.conversion_method,
+            "conversion_method_version": self.conversion_method_version,
+            "is_certification_approved": self.is_certification_approved,
+            "monthly_data_available": self.monthly_data_available,
+            "peak_load_data_available": self.peak_load_data_available,
+            "assumptions": deepcopy(self.assumptions),
+        }
+
+    @classmethod
+    def from_dict(cls, _input_dict):
+        # type: (Dict[str, Any]) -> ClimateProvenance
+        obj = cls(
+            source_type=_input_dict.get("source_type", "legacy_unknown"),
+            source_name=_input_dict.get("source_name"),
+            source_uri=_input_dict.get("source_uri"),
+            source_version=_input_dict.get("source_version"),
+            source_checksum=_input_dict.get("source_checksum"),
+            conversion_method=_input_dict.get("conversion_method"),
+            conversion_method_version=_input_dict.get("conversion_method_version"),
+            is_certification_approved=_input_dict.get("is_certification_approved"),
+            monthly_data_available=_input_dict.get("monthly_data_available"),
+            peak_load_data_available=_input_dict.get("peak_load_data_available"),
+            assumptions=deepcopy(_input_dict.get("assumptions", {})),
+        )
+        obj.display_name = _input_dict.get("display_name", obj.display_name)
+        obj.identifier = _input_dict.get("identifier", obj.identifier)
+        obj.user_data = copy(_input_dict.get("user_data", {}))
+        return obj
+
+    def __copy__(self):
+        # type: () -> ClimateProvenance
+        obj = ClimateProvenance(
+            source_type=self.source_type,
+            source_name=self.source_name,
+            source_uri=self.source_uri,
+            source_version=self.source_version,
+            source_checksum=self.source_checksum,
+            conversion_method=self.conversion_method,
+            conversion_method_version=self.conversion_method_version,
+            is_certification_approved=self.is_certification_approved,
+            monthly_data_available=self.monthly_data_available,
+            peak_load_data_available=self.peak_load_data_available,
+            assumptions=deepcopy(self.assumptions),
+        )
+        obj.set_base_attrs_from_source(self)
+        return obj
+
+    def duplicate(self):
+        # type: () -> ClimateProvenance
+        return self.__copy__()
+
+
 class Climate(_base._Base):
     """Complete climate dataset for PH energy modeling.
 
@@ -561,7 +708,8 @@ class Climate(_base._Base):
         ground (Climate_Ground): Ground thermal properties.
         monthly_temps (Climate_MonthlyTempCollection): Monthly temperature data.
         monthly_radiation (Climate_MonthlyRadiationCollection): Monthly radiation data.
-        peak_loads (Climate_PeakLoadCollection): Peak load design conditions.
+        peak_loads (Optional[Climate_PeakLoadCollection]): Peak load design conditions.
+        provenance (Optional[ClimateProvenance]): Source and availability metadata.
     """
 
     def __init__(
@@ -573,8 +721,9 @@ class Climate(_base._Base):
         _monthly_temps=None,
         _monthly_radiation=None,
         _peak_loads=None,
+        _provenance=None,
     ):
-        # type: (str, float, float, float, Optional[Climate_MonthlyTempCollection], Optional[Climate_MonthlyRadiationCollection], Optional[Climate_PeakLoadCollection]) -> None
+        # type: (str, float, float, float, Optional[Climate_MonthlyTempCollection], Optional[Climate_MonthlyRadiationCollection], Optional[Climate_PeakLoadCollection], Optional[ClimateProvenance]) -> None
         super(Climate, self).__init__()
         self.display_name = _display_name
         self.station_elevation = _station_elevation  # m
@@ -586,7 +735,14 @@ class Climate(_base._Base):
         self.monthly_radiation = (
             _monthly_radiation if _monthly_radiation is not None else Climate_MonthlyRadiationCollection()
         )
-        self.peak_loads = _peak_loads if _peak_loads is not None else Climate_PeakLoadCollection()
+        self.provenance = _provenance
+        peak_loads_unavailable = self.provenance is not None and self.provenance.peak_load_data_available is False
+        if _peak_loads is not None:
+            self.peak_loads = _peak_loads
+        elif peak_loads_unavailable:
+            self.peak_loads = None
+        else:
+            self.peak_loads = Climate_PeakLoadCollection()
 
     def to_dict(self):
         # type: () -> Dict
@@ -602,13 +758,19 @@ class Climate(_base._Base):
         d["ground"] = self.ground.to_dict()
         d["monthly_temps"] = self.monthly_temps.to_dict()
         d["monthly_radiation"] = self.monthly_radiation.to_dict()
-        d["peak_loads"] = self.peak_loads.to_dict()
+        d["peak_loads"] = self.peak_loads.to_dict() if self.peak_loads is not None else None
+        if self.provenance is not None:
+            d["provenance"] = self.provenance.to_dict()
 
         return d
 
     @classmethod
     def from_dict(cls, _input_dict):
         # type: (Dict) -> Climate
+        peak_loads_dict = _input_dict.get("peak_loads")
+        peak_loads = Climate_PeakLoadCollection.from_dict(peak_loads_dict) if peak_loads_dict is not None else None
+        peak_loads_is_explicit_null = "peak_loads" in _input_dict and peak_loads_dict is None
+        provenance_dict = _input_dict.get("provenance")
         obj = cls(
             _display_name=_input_dict.get("display_name", "New York"),
             _station_elevation=_input_dict["station_elevation"],
@@ -616,8 +778,11 @@ class Climate(_base._Base):
             _average_wind_speed=_input_dict["average_wind_speed"],
             _monthly_temps=Climate_MonthlyTempCollection.from_dict(_input_dict.get("monthly_temps", {})),
             _monthly_radiation=Climate_MonthlyRadiationCollection.from_dict(_input_dict.get("monthly_radiation", {})),
-            _peak_loads=Climate_PeakLoadCollection.from_dict(_input_dict.get("peak_loads", {})),
+            _peak_loads=peak_loads,
+            _provenance=ClimateProvenance.from_dict(provenance_dict) if provenance_dict is not None else None,
         )
+        if peak_loads_is_explicit_null:
+            obj.peak_loads = None
         obj.identifier = _input_dict.get("identifier", obj.identifier)
         obj.user_data = copy(_input_dict.get("user_data", {}))
         obj.ground = Climate_Ground.from_dict(_input_dict.get("ground", {}))
@@ -633,8 +798,11 @@ class Climate(_base._Base):
             self.average_wind_speed,
             self.monthly_temps.duplicate(),
             self.monthly_radiation.duplicate(),
-            self.peak_loads.duplicate(),
+            self.peak_loads.duplicate() if self.peak_loads is not None else None,
+            self.provenance.duplicate() if self.provenance is not None else None,
         )
+        if self.peak_loads is None:
+            obj.peak_loads = None
         obj.set_base_attrs_from_source(self)
         obj.ground = self.ground.duplicate()
         modeled_attributes = {
@@ -648,6 +816,7 @@ class Climate(_base._Base):
             "monthly_temps",
             "monthly_radiation",
             "peak_loads",
+            "provenance",
         }
         for attr_name, attr_value in vars(self).items():
             if attr_name not in modeled_attributes:
@@ -658,6 +827,85 @@ class Climate(_base._Base):
     def duplicate(self):
         # type: () -> Climate
         return self.__copy__()
+
+    def monthly_demand_readiness_issues(self):
+        # type: () -> List[str]
+        """Return deterministic issues preventing monthly-demand use."""
+        if self.provenance is None:
+            return ["provenance: monthly climate data availability is unknown for this legacy climate."]
+        if self.provenance.monthly_data_available is False:
+            return ["provenance.monthly_data_available: monthly climate data is explicitly unavailable."]
+        if self.provenance.monthly_data_available is None:
+            return ["provenance.monthly_data_available: monthly climate data availability is unknown."]
+
+        issues = []
+        scalar_fields = (
+            ("station_elevation", self.station_elevation),
+            ("summer_daily_temperature_swing", self.summer_daily_temperature_swing),
+            ("average_wind_speed", self.average_wind_speed),
+        )
+        monthly_fields = (
+            ("monthly_temps.air_temps", self.monthly_temps.air_temps),
+            ("monthly_temps.dewpoints", self.monthly_temps.dewpoints),
+            ("monthly_temps.sky_temps", self.monthly_temps.sky_temps),
+            ("monthly_temps.ground_temps", self.monthly_temps.ground_temps),
+            ("monthly_radiation.north", self.monthly_radiation.north),
+            ("monthly_radiation.east", self.monthly_radiation.east),
+            ("monthly_radiation.south", self.monthly_radiation.south),
+            ("monthly_radiation.west", self.monthly_radiation.west),
+            ("monthly_radiation.glob", self.monthly_radiation.glob),
+        )
+        for field_name, value in scalar_fields:
+            issue = _finite_value_issue(field_name, value)
+            if issue:
+                issues.append(issue)
+        for field_name, value_set in monthly_fields:
+            for month_name, value in zip(value_set.months, value_set.values):
+                issue = _finite_value_issue("{}.{}".format(field_name, month_name), value)
+                if issue:
+                    issues.append(issue)
+        return issues
+
+    @property
+    def is_monthly_demand_ready(self):
+        # type: () -> bool
+        """Whether all explicitly available monthly-demand fields are finite."""
+        return not self.monthly_demand_readiness_issues()
+
+    def peak_load_readiness_issues(self):
+        # type: () -> List[str]
+        """Return deterministic issues preventing peak-load use."""
+        if self.provenance is None:
+            return ["provenance: peak-load climate data availability is unknown for this legacy climate."]
+        if self.provenance.peak_load_data_available is False:
+            return [
+                "provenance.peak_load_data_available: approved or specialized peak-load climate data must be supplied separately."
+            ]
+        if self.provenance.peak_load_data_available is None:
+            return ["provenance.peak_load_data_available: peak-load climate data availability is unknown."]
+        if self.peak_loads is None:
+            return ["peak_loads: data is marked available but no peak-load collection is present."]
+
+        issues = []
+        load_sets = (
+            ("peak_loads.heat_load_1", self.peak_loads.heat_load_1),
+            ("peak_loads.heat_load_2", self.peak_loads.heat_load_2),
+            ("peak_loads.cooling_load_1", self.peak_loads.cooling_load_1),
+            ("peak_loads.cooling_load_2", self.peak_loads.cooling_load_2),
+        )
+        value_names = ("temp", "rad_north", "rad_east", "rad_south", "rad_west", "rad_global")
+        for field_name, value_set in load_sets:
+            for value_name in value_names:
+                issue = _finite_value_issue("{}.{}".format(field_name, value_name), getattr(value_set, value_name))
+                if issue:
+                    issues.append(issue)
+        return issues
+
+    @property
+    def is_peak_load_ready(self):
+        # type: () -> bool
+        """Whether all explicitly available peak-load fields are finite."""
+        return not self.peak_load_readiness_issues()
 
 
 class Location(_base._Base):
@@ -774,6 +1022,12 @@ class PHPPCodes(_base._Base):
         d["user_data"] = copy(self.user_data)
 
         return d
+
+    @classmethod
+    def blank(cls):
+        # type: () -> PHPPCodes
+        """Create a record with no PHPP climate-library identity."""
+        return cls("", "", "")
 
     @classmethod
     def from_dict(cls, _input_dict):

--- a/planning/STATUS.md
+++ b/planning/STATUS.md
@@ -8,7 +8,7 @@ _Last updated: 2026-08-14_
 
 | Item | Kind | Status | Pointer |
 |------|------|--------|---------|
-| EPW-derived preliminary monthly climate + provenance/readiness | Feature (cross-repo readiness, **primary**) | **In progress** — Phases 01–03 complete; Phase 04 next; PHX readiness remains a release blocker | [`features/epw-derived-preliminary-climate/`](features/epw-derived-preliminary-climate/README.md) → [decision 0004](../context/decisions/0004-no-bundled-licensed-climate-data.md) |
+| EPW-derived preliminary monthly climate + provenance/readiness | Feature (cross-repo readiness, **primary**) | **In progress** — Phases 01–04 complete; Phase 05 packaging/downstream/release next; PHX readiness remains a release blocker | [`features/epw-derived-preliminary-climate/`](features/epw-derived-preliminary-climate/README.md) → [decision 0004](../context/decisions/0004-no-bundled-licensed-climate-data.md) |
 | Explicit `PhVentilationSystem` factories | Feature (cross-repo) | **Scoped** — local API fixed; Phase 01 state matrix required before code | [`features/default-ventilation-system-factory/`](features/default-ventilation-system-factory/README.md) |
 | Default dwelling identity across HBJSON round-trips | Bug fix | **Requested** — reproduced in PHX; not implemented | [`refactor/dwelling-default-roundtrip.md`](refactor/dwelling-default-roundtrip.md) |
 | Decouple "Dwelling" from `Room.zone` | Refactor (cross-repo, **primary**) | **Released** in v1.33.30 — downstream install/PHX status remains in companion docs | [`refactor/dwelling-zone-decoupling.md`](refactor/dwelling-zone-decoupling.md) → [decision 0002](../context/decisions/0002-dwelling-identity-not-room-zone.md) |

--- a/planning/STATUS.md
+++ b/planning/STATUS.md
@@ -8,7 +8,7 @@ _Last updated: 2026-08-14_
 
 | Item | Kind | Status | Pointer |
 |------|------|--------|---------|
-| EPW-derived preliminary monthly climate + provenance/readiness | Feature (cross-repo readiness, **primary**) | **In progress** — Phases 01–04 complete; Phase 05 packaging/downstream/release next; PHX readiness remains a release blocker | [`features/epw-derived-preliminary-climate/`](features/epw-derived-preliminary-climate/README.md) → [decision 0004](../context/decisions/0004-no-bundled-licensed-climate-data.md) |
+| EPW-derived preliminary monthly climate + provenance/readiness | Feature (cross-repo readiness, **primary**) | **In progress** — Phases 01–04 + Phase 05 local/downstream work complete; expected v1.33.40 release, PHX >=1.33.40 pin/release, and archive remain | [`features/epw-derived-preliminary-climate/`](features/epw-derived-preliminary-climate/README.md) → [decision 0004](../context/decisions/0004-no-bundled-licensed-climate-data.md) |
 | Explicit `PhVentilationSystem` factories | Feature (cross-repo) | **Scoped** — local API fixed; Phase 01 state matrix required before code | [`features/default-ventilation-system-factory/`](features/default-ventilation-system-factory/README.md) |
 | Default dwelling identity across HBJSON round-trips | Bug fix | **Requested** — reproduced in PHX; not implemented | [`refactor/dwelling-default-roundtrip.md`](refactor/dwelling-default-roundtrip.md) |
 | Decouple "Dwelling" from `Room.zone` | Refactor (cross-repo, **primary**) | **Released** in v1.33.30 — downstream install/PHX status remains in companion docs | [`refactor/dwelling-zone-decoupling.md`](refactor/dwelling-zone-decoupling.md) → [decision 0002](../context/decisions/0002-dwelling-identity-not-room-zone.md) |

--- a/planning/STATUS.md
+++ b/planning/STATUS.md
@@ -8,7 +8,7 @@ _Last updated: 2026-08-14_
 
 | Item | Kind | Status | Pointer |
 |------|------|--------|---------|
-| EPW-derived preliminary monthly climate + provenance/readiness | Feature (cross-repo readiness, **primary**) | **In progress** — Phases 01–02 complete; Phase 03 next; PHX readiness remains a release blocker | [`features/epw-derived-preliminary-climate/`](features/epw-derived-preliminary-climate/README.md) → [decision 0004](../context/decisions/0004-no-bundled-licensed-climate-data.md) |
+| EPW-derived preliminary monthly climate + provenance/readiness | Feature (cross-repo readiness, **primary**) | **In progress** — Phases 01–03 complete; Phase 04 next; PHX readiness remains a release blocker | [`features/epw-derived-preliminary-climate/`](features/epw-derived-preliminary-climate/README.md) → [decision 0004](../context/decisions/0004-no-bundled-licensed-climate-data.md) |
 | Explicit `PhVentilationSystem` factories | Feature (cross-repo) | **Scoped** — local API fixed; Phase 01 state matrix required before code | [`features/default-ventilation-system-factory/`](features/default-ventilation-system-factory/README.md) |
 | Default dwelling identity across HBJSON round-trips | Bug fix | **Requested** — reproduced in PHX; not implemented | [`refactor/dwelling-default-roundtrip.md`](refactor/dwelling-default-roundtrip.md) |
 | Decouple "Dwelling" from `Room.zone` | Refactor (cross-repo, **primary**) | **Released** in v1.33.30 — downstream install/PHX status remains in companion docs | [`refactor/dwelling-zone-decoupling.md`](refactor/dwelling-zone-decoupling.md) → [decision 0002](../context/decisions/0002-dwelling-identity-not-room-zone.md) |

--- a/planning/STATUS.md
+++ b/planning/STATUS.md
@@ -8,7 +8,7 @@ _Last updated: 2026-08-14_
 
 | Item | Kind | Status | Pointer |
 |------|------|--------|---------|
-| EPW-derived preliminary monthly climate + provenance/readiness | Feature (cross-repo readiness, **primary**) | **In progress** — Phase 01 complete; Phase 02 next; PHX readiness remains a release blocker | [`features/epw-derived-preliminary-climate/`](features/epw-derived-preliminary-climate/README.md) → [decision 0004](../context/decisions/0004-no-bundled-licensed-climate-data.md) |
+| EPW-derived preliminary monthly climate + provenance/readiness | Feature (cross-repo readiness, **primary**) | **In progress** — Phases 01–02 complete; Phase 03 next; PHX readiness remains a release blocker | [`features/epw-derived-preliminary-climate/`](features/epw-derived-preliminary-climate/README.md) → [decision 0004](../context/decisions/0004-no-bundled-licensed-climate-data.md) |
 | Explicit `PhVentilationSystem` factories | Feature (cross-repo) | **Scoped** — local API fixed; Phase 01 state matrix required before code | [`features/default-ventilation-system-factory/`](features/default-ventilation-system-factory/README.md) |
 | Default dwelling identity across HBJSON round-trips | Bug fix | **Requested** — reproduced in PHX; not implemented | [`refactor/dwelling-default-roundtrip.md`](refactor/dwelling-default-roundtrip.md) |
 | Decouple "Dwelling" from `Room.zone` | Refactor (cross-repo, **primary**) | **Released** in v1.33.30 — downstream install/PHX status remains in companion docs | [`refactor/dwelling-zone-decoupling.md`](refactor/dwelling-zone-decoupling.md) → [decision 0002](../context/decisions/0002-dwelling-identity-not-room-zone.md) |

--- a/planning/STATUS.md
+++ b/planning/STATUS.md
@@ -8,7 +8,7 @@ _Last updated: 2026-08-14_
 
 | Item | Kind | Status | Pointer |
 |------|------|--------|---------|
-| EPW-derived preliminary monthly climate + provenance/readiness | Feature (cross-repo readiness, **primary**) | **Scoped** — replaces bundled dataset proposal; blocked until `honeybee-ph>=1.33.35` is published and verified | [`features/epw-derived-preliminary-climate/`](features/epw-derived-preliminary-climate/README.md) → [decision 0004](../context/decisions/0004-no-bundled-licensed-climate-data.md) |
+| EPW-derived preliminary monthly climate + provenance/readiness | Feature (cross-repo readiness, **primary**) | **In progress** — Phase 01 complete; Phase 02 next; PHX readiness remains a release blocker | [`features/epw-derived-preliminary-climate/`](features/epw-derived-preliminary-climate/README.md) → [decision 0004](../context/decisions/0004-no-bundled-licensed-climate-data.md) |
 | Explicit `PhVentilationSystem` factories | Feature (cross-repo) | **Scoped** — local API fixed; Phase 01 state matrix required before code | [`features/default-ventilation-system-factory/`](features/default-ventilation-system-factory/README.md) |
 | Default dwelling identity across HBJSON round-trips | Bug fix | **Requested** — reproduced in PHX; not implemented | [`refactor/dwelling-default-roundtrip.md`](refactor/dwelling-default-roundtrip.md) |
 | Decouple "Dwelling" from `Room.zone` | Refactor (cross-repo, **primary**) | **Released** in v1.33.30 — downstream install/PHX status remains in companion docs | [`refactor/dwelling-zone-decoupling.md`](refactor/dwelling-zone-decoupling.md) → [decision 0002](../context/decisions/0002-dwelling-identity-not-room-zone.md) |

--- a/planning/features/epw-derived-preliminary-climate/PLAN.md
+++ b/planning/features/epw-derived-preliminary-climate/PLAN.md
@@ -6,7 +6,7 @@ requested.
 
 | Phase | Objective | Gate |
 |---:|---|---|
-| 01 | Freeze provenance, completeness, serialization, and downstream contracts | Published `honeybee-ph>=1.33.35` verified; schema review accepted |
+| 01 ✅ | Freeze provenance, completeness, serialization, and downstream contracts | Complete; PyPI `1.33.39` prerequisite and focused contract tests verified |
 | 02 | Implement EPW parsing, source validation, location, scalars, and monthly temperatures | Phase 01 tests/contract stable |
 | 03 | Implement directional monthly radiation and explicit ground-temperature selection | Phase 02 complete |
 | 04 | Add `Site.from_epw()`, readiness checks, duplication, and HBJSON integration | Phases 02–03 complete |

--- a/planning/features/epw-derived-preliminary-climate/PLAN.md
+++ b/planning/features/epw-derived-preliminary-climate/PLAN.md
@@ -9,7 +9,7 @@ requested.
 | 01 ✅ | Freeze provenance, completeness, serialization, and downstream contracts | Complete; PyPI `1.33.39` prerequisite and focused contract tests verified |
 | 02 ✅ | Implement EPW parsing, source validation, location, scalars, and monthly temperatures | Complete; synthetic EPW suite has 100% branch coverage for the converter |
 | 03 ✅ | Implement directional monthly radiation and explicit ground-temperature selection | Complete; 36 focused synthetic EPW tests verified |
-| 04 | Add `Site.from_epw()`, readiness checks, duplication, and HBJSON integration | Phases 02–03 complete |
+| 04 ✅ | Add `Site.from_epw()`, readiness checks, duplication, and HBJSON integration | Complete; 52 focused converter/integration/readiness tests verified |
 | 05 | Verify packaging, IronPython compatibility, docs, downstream diagnostics, and release | Focused and full tests green |
 
 Phase documents:

--- a/planning/features/epw-derived-preliminary-climate/PLAN.md
+++ b/planning/features/epw-derived-preliminary-climate/PLAN.md
@@ -8,7 +8,7 @@ requested.
 |---:|---|---|
 | 01 ✅ | Freeze provenance, completeness, serialization, and downstream contracts | Complete; PyPI `1.33.39` prerequisite and focused contract tests verified |
 | 02 ✅ | Implement EPW parsing, source validation, location, scalars, and monthly temperatures | Complete; synthetic EPW suite has 100% branch coverage for the converter |
-| 03 | Implement directional monthly radiation and explicit ground-temperature selection | Phase 02 complete |
+| 03 ✅ | Implement directional monthly radiation and explicit ground-temperature selection | Complete; 36 focused synthetic EPW tests verified |
 | 04 | Add `Site.from_epw()`, readiness checks, duplication, and HBJSON integration | Phases 02–03 complete |
 | 05 | Verify packaging, IronPython compatibility, docs, downstream diagnostics, and release | Focused and full tests green |
 

--- a/planning/features/epw-derived-preliminary-climate/PLAN.md
+++ b/planning/features/epw-derived-preliminary-climate/PLAN.md
@@ -10,7 +10,7 @@ requested.
 | 02 ✅ | Implement EPW parsing, source validation, location, scalars, and monthly temperatures | Complete; synthetic EPW suite has 100% branch coverage for the converter |
 | 03 ✅ | Implement directional monthly radiation and explicit ground-temperature selection | Complete; 36 focused synthetic EPW tests verified |
 | 04 ✅ | Add `Site.from_epw()`, readiness checks, duplication, and HBJSON integration | Complete; 52 focused converter/integration/readiness tests verified |
-| 05 | Verify packaging, IronPython compatibility, docs, downstream diagnostics, and release | Focused and full tests green |
+| 05 | Verify packaging, IronPython compatibility, docs, downstream diagnostics, and release | Local/package/PHX/OpenPH checks complete; v1.33.40 + PHX pin/release verification pending |
 
 Phase documents:
 

--- a/planning/features/epw-derived-preliminary-climate/PLAN.md
+++ b/planning/features/epw-derived-preliminary-climate/PLAN.md
@@ -7,7 +7,7 @@ requested.
 | Phase | Objective | Gate |
 |---:|---|---|
 | 01 ✅ | Freeze provenance, completeness, serialization, and downstream contracts | Complete; PyPI `1.33.39` prerequisite and focused contract tests verified |
-| 02 | Implement EPW parsing, source validation, location, scalars, and monthly temperatures | Phase 01 tests/contract stable |
+| 02 ✅ | Implement EPW parsing, source validation, location, scalars, and monthly temperatures | Complete; synthetic EPW suite has 100% branch coverage for the converter |
 | 03 | Implement directional monthly radiation and explicit ground-temperature selection | Phase 02 complete |
 | 04 | Add `Site.from_epw()`, readiness checks, duplication, and HBJSON integration | Phases 02–03 complete |
 | 05 | Verify packaging, IronPython compatibility, docs, downstream diagnostics, and release | Focused and full tests green |

--- a/planning/features/epw-derived-preliminary-climate/PRD.md
+++ b/planning/features/epw-derived-preliminary-climate/PRD.md
@@ -1,6 +1,6 @@
 # PRD — EPW-derived preliminary monthly climate
 
-**Status:** In progress · Phases 01–03 complete · 2026-08-14
+**Status:** In progress · Phases 01–04 complete · 2026-08-14
 **Author:** Ed May + Codex
 **Kind:** Feature / data-contract extension (this repo primary; downstream
 readiness coordination required)

--- a/planning/features/epw-derived-preliminary-climate/PRD.md
+++ b/planning/features/epw-derived-preliminary-climate/PRD.md
@@ -1,6 +1,6 @@
 # PRD — EPW-derived preliminary monthly climate
 
-**Status:** In progress · Phases 01–02 complete · 2026-08-14
+**Status:** In progress · Phases 01–03 complete · 2026-08-14
 **Author:** Ed May + Codex
 **Kind:** Feature / data-contract extension (this repo primary; downstream
 readiness coordination required)

--- a/planning/features/epw-derived-preliminary-climate/PRD.md
+++ b/planning/features/epw-derived-preliminary-climate/PRD.md
@@ -1,6 +1,6 @@
 # PRD — EPW-derived preliminary monthly climate
 
-**Status:** In progress · Phases 01–04 complete · 2026-08-14
+**Status:** In progress · Phases 01–04 complete · Phase 05 release handoff · 2026-08-14
 **Author:** Ed May + Codex
 **Kind:** Feature / data-contract extension (this repo primary; downstream
 readiness coordination required)

--- a/planning/features/epw-derived-preliminary-climate/PRD.md
+++ b/planning/features/epw-derived-preliminary-climate/PRD.md
@@ -1,6 +1,6 @@
 # PRD — EPW-derived preliminary monthly climate
 
-**Status:** In progress · Phase 01 complete · 2026-08-14
+**Status:** In progress · Phases 01–02 complete · 2026-08-14
 **Author:** Ed May + Codex
 **Kind:** Feature / data-contract extension (this repo primary; downstream
 readiness coordination required)

--- a/planning/features/epw-derived-preliminary-climate/PRD.md
+++ b/planning/features/epw-derived-preliminary-climate/PRD.md
@@ -1,6 +1,6 @@
 # PRD — EPW-derived preliminary monthly climate
 
-**Status:** Scoped · 2026-08-14
+**Status:** In progress · Phase 01 complete · 2026-08-14
 **Author:** Ed May + Codex
 **Kind:** Feature / data-contract extension (this repo primary; downstream
 readiness coordination required)

--- a/planning/features/epw-derived-preliminary-climate/README.md
+++ b/planning/features/epw-derived-preliminary-climate/README.md
@@ -1,6 +1,6 @@
 # epw-derived-preliminary-climate — router
 
-**Status:** Scoped · implementation not started
+**Status:** In progress · Phase 01 complete
 
 **Scope:** Convert a caller-supplied EPW into a provenance-bearing,
 explicitly preliminary `Site` suitable for monthly design exploration. Bundle

--- a/planning/features/epw-derived-preliminary-climate/README.md
+++ b/planning/features/epw-derived-preliminary-climate/README.md
@@ -1,6 +1,6 @@
 # epw-derived-preliminary-climate — router
 
-**Status:** In progress · Phase 01 complete
+**Status:** In progress · Phases 01–02 complete
 
 **Scope:** Convert a caller-supplied EPW into a provenance-bearing,
 explicitly preliminary `Site` suitable for monthly design exploration. Bundle

--- a/planning/features/epw-derived-preliminary-climate/README.md
+++ b/planning/features/epw-derived-preliminary-climate/README.md
@@ -1,6 +1,6 @@
 # epw-derived-preliminary-climate — router
 
-**Status:** In progress · Phases 01–04 complete
+**Status:** In progress · Phases 01–04 complete · Phase 05 release handoff
 
 **Scope:** Convert a caller-supplied EPW into a provenance-bearing,
 explicitly preliminary `Site` suitable for monthly design exploration. Bundle

--- a/planning/features/epw-derived-preliminary-climate/README.md
+++ b/planning/features/epw-derived-preliminary-climate/README.md
@@ -1,6 +1,6 @@
 # epw-derived-preliminary-climate — router
 
-**Status:** In progress · Phases 01–02 complete
+**Status:** In progress · Phases 01–03 complete
 
 **Scope:** Convert a caller-supplied EPW into a provenance-bearing,
 explicitly preliminary `Site` suitable for monthly design exploration. Bundle

--- a/planning/features/epw-derived-preliminary-climate/README.md
+++ b/planning/features/epw-derived-preliminary-climate/README.md
@@ -1,6 +1,6 @@
 # epw-derived-preliminary-climate — router
 
-**Status:** In progress · Phases 01–03 complete
+**Status:** In progress · Phases 01–04 complete
 
 **Scope:** Convert a caller-supplied EPW into a provenance-bearing,
 explicitly preliminary `Site` suitable for monthly design exploration. Bundle

--- a/planning/features/epw-derived-preliminary-climate/STATUS.md
+++ b/planning/features/epw-derived-preliminary-climate/STATUS.md
@@ -1,6 +1,6 @@
 # STATUS — epw-derived-preliminary-climate
 
-**Status:** In progress · Phases 01–04 complete · 2026-08-14
+**Status:** In progress · Phases 01–04 complete · Phase 05 release handoff · 2026-08-14
 
 - Replaces the superseded bundled climate-dataset proposal.
 - Product/IP boundary is decided in context decision 0004.
@@ -20,11 +20,21 @@
   ASHRAE climate zone, blank PHPP codes, null peak loads, JSON/HBJSON host
   round-trips, and recursive independence verification.
 - No in-repo consumer outside `site.py` dereferences peak loads or requires
-  nonblank PHPP climate codes; the identified unsafe consumer remains in PHX.
-- **Next step:** execute Phase 05: packaging/docs verification and coordinated
-  downstream readiness diagnostics before release.
-- Release blocker: downstream PHX readiness behavior must be implemented and
-  verified; no adjacent OpenPH checkout was available for a direct audit.
+  nonblank PHPP climate codes; the identified PHX consumer is now guarded on
+  its companion branch.
+- Phase 05 local verification is complete: public docs/context are updated;
+  built sdist/wheel contain no EPW or copied climate dataset; built-wheel
+  conversion passes under CPython 3.10.
+- PHX readiness is implemented on
+  `codex/epw-derived-preliminary-climate-readiness` at `2e8864c`; 881 PHX tests
+  pass against its locked dependency and focused integration passes against
+  this feature checkout.
+- OpenPH was located under `openph-workspace` and audited. It has no direct
+  honeybee-ph climate ingestion; the canonical PHX boundary now rejects the
+  monthly-only state before OpenPH construction.
+- **Next step / release blocker:** merge and release expected
+  `honeybee-ph==1.33.40`, verify the published artifact, raise/lock PHX to
+  `honeybee-ph>=1.33.40`, verify/release PHX, then archive this packet.
 - Do not add or copy any real PHI/Phius/EPW dataset into this repository while
   implementing or testing. Generate a minimal synthetic EPW fixture or use a
   license-compatible test fixture with its terms recorded.

--- a/planning/features/epw-derived-preliminary-climate/STATUS.md
+++ b/planning/features/epw-derived-preliminary-climate/STATUS.md
@@ -1,6 +1,6 @@
 # STATUS — epw-derived-preliminary-climate
 
-**Status:** In progress · Phase 01 complete · 2026-08-14
+**Status:** In progress · Phases 01–02 complete · 2026-08-14
 
 - Replaces the superseded bundled climate-dataset proposal.
 - Product/IP boundary is decided in context decision 0004.
@@ -10,8 +10,11 @@
   required `>=1.33.35` independent-site baseline.
 - Phase 01 adds the provenance model, additive HBJSON contract, explicit null
   peak-load state, blank PHPP codes, and deterministic readiness diagnostics.
-- **Next step:** execute Phase 02: validated EPW location, scalar, and monthly
-  temperature conversion without adding the public `Site.from_epw()` entry point.
+- Phase 02 adds the internal, snapshot-consistent Ladybug EPW converter with
+  path/header/cardinality/value validation, location/scalars, monthly dry-bulb,
+  dewpoint, and sky temperatures, warm-season swing, and SHA-256 provenance.
+- **Next step:** execute Phase 03: directional/global monthly radiation and
+  explicit ground-temperature depth selection.
 - Release blocker: downstream PHX readiness behavior must be implemented and
   verified; no adjacent OpenPH checkout was available for a direct audit.
 - Do not add or copy any real PHI/Phius/EPW dataset into this repository while

--- a/planning/features/epw-derived-preliminary-climate/STATUS.md
+++ b/planning/features/epw-derived-preliminary-climate/STATUS.md
@@ -1,6 +1,6 @@
 # STATUS — epw-derived-preliminary-climate
 
-**Status:** In progress · Phases 01–02 complete · 2026-08-14
+**Status:** In progress · Phases 01–03 complete · 2026-08-14
 
 - Replaces the superseded bundled climate-dataset proposal.
 - Product/IP boundary is decided in context decision 0004.
@@ -13,8 +13,11 @@
 - Phase 02 adds the internal, snapshot-consistent Ladybug EPW converter with
   path/header/cardinality/value validation, location/scalars, monthly dry-bulb,
   dewpoint, and sky temperatures, warm-season swing, and SHA-256 provenance.
-- **Next step:** execute Phase 03: directional/global monthly radiation and
-  explicit ground-temperature depth selection.
+- Phase 03 adds global-horizontal and cardinal vertical-plane monthly
+  radiation, explicit diffuse/reflectance assumptions, and deterministic EPW
+  ground-temperature depth selection without inferred fallback values.
+- **Next step:** execute Phase 04: public `Site.from_epw()` integration,
+  independence, HBJSON round-trips, and readiness verification.
 - Release blocker: downstream PHX readiness behavior must be implemented and
   verified; no adjacent OpenPH checkout was available for a direct audit.
 - Do not add or copy any real PHI/Phius/EPW dataset into this repository while

--- a/planning/features/epw-derived-preliminary-climate/STATUS.md
+++ b/planning/features/epw-derived-preliminary-climate/STATUS.md
@@ -1,6 +1,6 @@
 # STATUS — epw-derived-preliminary-climate
 
-**Status:** In progress · Phases 01–03 complete · 2026-08-14
+**Status:** In progress · Phases 01–04 complete · 2026-08-14
 
 - Replaces the superseded bundled climate-dataset proposal.
 - Product/IP boundary is decided in context decision 0004.
@@ -16,8 +16,13 @@
 - Phase 03 adds global-horizontal and cardinal vertical-plane monthly
   radiation, explicit diffuse/reflectance assumptions, and deterministic EPW
   ground-temperature depth selection without inferred fallback values.
-- **Next step:** execute Phase 04: public `Site.from_epw()` integration,
-  independence, HBJSON round-trips, and readiness verification.
+- Phase 04 adds the public `Site.from_epw()` factory, explicitly unknown
+  ASHRAE climate zone, blank PHPP codes, null peak loads, JSON/HBJSON host
+  round-trips, and recursive independence verification.
+- No in-repo consumer outside `site.py` dereferences peak loads or requires
+  nonblank PHPP climate codes; the identified unsafe consumer remains in PHX.
+- **Next step:** execute Phase 05: packaging/docs verification and coordinated
+  downstream readiness diagnostics before release.
 - Release blocker: downstream PHX readiness behavior must be implemented and
   verified; no adjacent OpenPH checkout was available for a direct audit.
 - Do not add or copy any real PHI/Phius/EPW dataset into this repository while

--- a/planning/features/epw-derived-preliminary-climate/STATUS.md
+++ b/planning/features/epw-derived-preliminary-climate/STATUS.md
@@ -1,17 +1,19 @@
 # STATUS — epw-derived-preliminary-climate
 
-**Status:** Scoped · 2026-08-14
+**Status:** In progress · Phase 01 complete · 2026-08-14
 
 - Replaces the superseded bundled climate-dataset proposal.
 - Product/IP boundary is decided in context decision 0004.
 - Public shape, provenance fields, monthly conversion rules, peak-load
   exclusion, and validation expectations are specified in `PRD.md`.
-- Prerequisite: `independent-site-defaults` is complete and archived; verify
-  the published `honeybee-ph>=1.33.35` artifact before implementation begins.
-- **Next step:** execute Phase 01 and freeze additive HBJSON/provenance and
-  nullable peak-load compatibility before writing conversion code.
-- Blockers: publication and verification of `honeybee-ph>=1.33.35`; downstream
-  PHX/OpenPH readiness behavior must also be verified before release.
+- Prerequisite verified: PyPI publishes `honeybee-ph 1.33.39`, including the
+  required `>=1.33.35` independent-site baseline.
+- Phase 01 adds the provenance model, additive HBJSON contract, explicit null
+  peak-load state, blank PHPP codes, and deterministic readiness diagnostics.
+- **Next step:** execute Phase 02: validated EPW location, scalar, and monthly
+  temperature conversion without adding the public `Site.from_epw()` entry point.
+- Release blocker: downstream PHX readiness behavior must be implemented and
+  verified; no adjacent OpenPH checkout was available for a direct audit.
 - Do not add or copy any real PHI/Phius/EPW dataset into this repository while
   implementing or testing. Generate a minimal synthetic EPW fixture or use a
   license-compatible test fixture with its terms recorded.

--- a/planning/features/epw-derived-preliminary-climate/phases/phase-01-provenance-and-completeness-contract.md
+++ b/planning/features/epw-derived-preliminary-climate/phases/phase-01-provenance-and-completeness-contract.md
@@ -1,5 +1,7 @@
 # Phase 01 — Provenance and completeness contract
 
+**Status:** Complete · 2026-08-14
+
 ## Objective
 
 Make approved, user-defined, EPW-derived, complete, incomplete, and legacy
@@ -43,3 +45,27 @@ unknown climate states distinguishable before adding any EPW conversion path.
 - No old HBJSON fixture regresses.
 - Downstream assumptions and follow-up touchpoints are listed in Phase 04/05.
 - No EPW parsing code has been added yet.
+
+## Completion evidence
+
+- PyPI lists `honeybee-ph 1.33.39`; the required `>=1.33.35` artifact is published.
+- Focused climate and graph-independence suite: `114 passed`.
+- Full coverage gate: `925 passed`, `79%` aggregate coverage.
+- Black, `git diff --check`, and Python 2.7 grammar parsing pass.
+- Default `Climate.to_dict()` remains provenance-free; missing peak loads retain
+  the legacy populated default, while explicit unavailable peak loads serialize as null.
+- `ClimateProvenance`, readiness issue ordering, zero-valued available data,
+  recursive duplication, and `PHPPCodes.blank()` are pinned by focused tests.
+- No EPW parser or fixture was added in this phase.
+
+## Downstream audit
+
+- PHX `phx/from_HBJSON/create_variant.py:417-456` dereferences all four peak-load
+  records unconditionally. Before release it must call the upstream readiness
+  contract and raise the specialized-data diagnostic instead of reading a null
+  collection or constructing zero-filled peak loads.
+- The same PHX mapping copies blank PHPP codes at lines 394-396; blank strings
+  are structurally safe, but exporter behavior must be verified in Phase 05.
+- No adjacent OpenPH checkout exists in this workspace; Phase 05 must verify its
+  current consumer behavior from an available checkout or record that it has no
+  honeybee-ph climate ingestion path.

--- a/planning/features/epw-derived-preliminary-climate/phases/phase-02-epw-location-and-temperature-conversion.md
+++ b/planning/features/epw-derived-preliminary-climate/phases/phase-02-epw-location-and-temperature-conversion.md
@@ -1,5 +1,7 @@
 # Phase 02 — EPW location and temperature conversion
 
+**Status:** Complete · 2026-08-14
+
 ## Objective
 
 Parse and validate a local EPW and derive location, scalar climate properties,
@@ -42,3 +44,17 @@ and monthly temperature collections with no silent fallback values.
 - No source missing value was converted to zero.
 - Focused tests maintain 100% branch coverage for the new module.
 
+## Completion evidence
+
+- `honeybee_ph._epw.convert_epw()` reads one immutable file snapshot for
+  SHA-256, validation, and `EPW.from_file_string()` conversion.
+- The generated test EPW contains only controlled synthetic values; no weather
+  observation or certification dataset is stored in the repository.
+- Focused suite: `21 passed`; `honeybee_ph/_epw.py` has 100% statement and
+  branch coverage.
+- Full coverage gate: `946 passed`, `80%` aggregate coverage; Black,
+  `git diff --check`, and Python 2.7 grammar parsing pass.
+- Leap/non-leap cardinality, malformed input, independent invalid values,
+  impossible location fields, southern warm-season wrap, deterministic method
+  metadata, and horizontal-infrared sky fallback are pinned.
+- The public `Site.from_epw()` entry point remains absent pending Phase 04.

--- a/planning/features/epw-derived-preliminary-climate/phases/phase-03-radiation-and-ground-conversion.md
+++ b/planning/features/epw-derived-preliminary-climate/phases/phase-03-radiation-and-ground-conversion.md
@@ -1,5 +1,7 @@
 # Phase 03 — Radiation and ground conversion
 
+**Status:** Complete · 2026-08-14
+
 ## Objective
 
 Complete preliminary monthly-demand inputs with documented directional solar
@@ -39,3 +41,11 @@ radiation and explicit EPW ground-temperature selection.
 - No PHI/Phius peak-load field has been synthesized.
 - Focused tests and `git diff --check` pass.
 
+## Completion evidence
+
+- `36 passed` in the focused synthetic EPW conversion suite.
+- Converter branch coverage: 98%; all radiation and ground-selection paths are
+  exercised, with only defensive I/O/type guards remaining uncovered.
+- Isolated option tests prove both ground reflectance and diffuse-model changes.
+- Full repository suite: `961 passed`; aggregate coverage: `80%`.
+- Black, Python 2 grammar parsing, and `git diff --check` pass.

--- a/planning/features/epw-derived-preliminary-climate/phases/phase-04-site-integration-and-readiness.md
+++ b/planning/features/epw-derived-preliminary-climate/phases/phase-04-site-integration-and-readiness.md
@@ -57,6 +57,6 @@ climates with `Climate.peak_load_readiness_issues()` before those reads.
 - EPW output uses `climate_zone=None`, blank PHPP codes, and `peak_loads=None`;
   no source field is invented from a legacy default.
 - Repository audit found no additional in-repo peak-load or PHPP-code consumer;
-  the PHX boundary remains the Phase 05 release blocker.
+  the PHX boundary was carried into Phase 05 for downstream implementation.
 - Full repository suite: `966 passed`; aggregate coverage: `80%`.
 - Black, Python 2 grammar parsing, and `git diff --check` pass.

--- a/planning/features/epw-derived-preliminary-climate/phases/phase-04-site-integration-and-readiness.md
+++ b/planning/features/epw-derived-preliminary-climate/phases/phase-04-site-integration-and-readiness.md
@@ -24,6 +24,11 @@ honest through duplication and HBJSON.
 6. Update any in-repo consumer that assumes non-null peak loads or nonblank
    PHPP codes; do not make downstream exporters invent values.
 
+Downstream touchpoint identified in Phase 01: PHX
+`phx/from_HBJSON/create_variant.py:417-456` unconditionally dereferences the
+four peak-load sets. Its HBJSON conversion boundary must reject monthly-only
+climates with `Climate.peak_load_readiness_issues()` before those reads.
+
 ## Tests
 
 - End-to-end EPW -> Site -> dict -> Site preserves values and provenance.
@@ -40,4 +45,3 @@ honest through duplication and HBJSON.
 - Serialization is backward compatible and explicit for new unavailable data.
 - Downstream changes required for safe conversion are implemented or block
   release in Phase 05.
-

--- a/planning/features/epw-derived-preliminary-climate/phases/phase-04-site-integration-and-readiness.md
+++ b/planning/features/epw-derived-preliminary-climate/phases/phase-04-site-integration-and-readiness.md
@@ -1,5 +1,7 @@
 # Phase 04 — Site integration and readiness
 
+**Status:** Complete · 2026-08-14
+
 ## Objective
 
 Expose the supported one-call API and prove that EPW-derived state remains
@@ -45,3 +47,16 @@ climates with `Climate.peak_load_readiness_issues()` before those reads.
 - Serialization is backward compatible and explicit for new unavailable data.
 - Downstream changes required for safe conversion are implemented or block
   release in Phase 05.
+
+## Completion evidence
+
+- `52 passed` across converter, public integration, and readiness tests.
+- `Site.from_epw()` forwards every documented option and returns a fresh graph.
+- JSON encoding with `allow_nan=False`, Site/BuildingSegment/Room paths,
+  duplication, and mutation isolation pass.
+- EPW output uses `climate_zone=None`, blank PHPP codes, and `peak_loads=None`;
+  no source field is invented from a legacy default.
+- Repository audit found no additional in-repo peak-load or PHPP-code consumer;
+  the PHX boundary remains the Phase 05 release blocker.
+- Full repository suite: `966 passed`; aggregate coverage: `80%`.
+- Black, Python 2 grammar parsing, and `git diff --check` pass.

--- a/planning/features/epw-derived-preliminary-climate/phases/phase-05-docs-downstream-and-release.md
+++ b/planning/features/epw-derived-preliminary-climate/phases/phase-05-docs-downstream-and-release.md
@@ -1,5 +1,8 @@
 # Phase 05 — Docs, downstream verification, and release
 
+**Status:** In progress · local implementation and downstream guard complete;
+release verification pending · 2026-08-14
+
 ## Objective
 
 Ship the EPW-derived path without bundled data, misleading certification
@@ -38,3 +41,30 @@ claims, IronPython regressions, or downstream zero fallbacks.
 - Docs never use `approved`, `certification`, `PHPP dataset`, or `Phius
   dataset` to describe EPW-derived values except to state the exclusion.
 - Release version and downstream minimum-version requirements are recorded.
+
+## Current evidence
+
+- Public EPW guide documents units, cardinal azimuths, radiation options,
+  ground-depth selection, readiness/provenance, PHX rejection, and the
+  non-certification/no-zero boundary.
+- `uv build` produced the `1.33.39` development sdist and wheel in a temporary
+  directory. Archive inspection found no `.epw` or copied climate dataset;
+  both `honeybee_ph/_epw.py` and `honeybee_ph/site.py` are present.
+- Import/conversion from the built wheel succeeds under CPython 3.10:
+  monthly ready, peak not ready, `source_type=epw_derived`, `peak_loads=None`.
+- Final honeybee-ph gate remains `966 passed` with `80%` aggregate coverage;
+  Black, Python 2 grammar parsing, and `git diff --check` pass.
+- PHX branch `codex/epw-derived-preliminary-climate-readiness`, commit
+  `2e8864c`, rejects explicit monthly or peak readiness issues before any
+  substantive variant builder. Legacy populated climate remains supported and
+  blank PHPP codes remain blank.
+- PHX verification: `881 passed, 3 skipped, 1 deselected` against its locked
+  `honeybee-ph`; 5 focused tests also pass against this feature checkout.
+- OpenPH workspace audit found no direct honeybee-ph climate ingestion. Its
+  canonical path consumes a PHX `PhxVariant`; the new PHX boundary rejects the
+  monthly-only state before OpenPH construction.
+- Expected upstream release target is `honeybee-ph==1.33.40`. Before the PHX
+  branch merges/releases, its downstream minimum must be raised to
+  `honeybee-ph>=1.33.40` and locked against the published artifact.
+- Remaining blocker: merge/release authorization, published-artifact
+  verification, PHX pin/release verification, then packet archive.

--- a/planning/features/epw-derived-preliminary-climate/phases/phase-05-docs-downstream-and-release.md
+++ b/planning/features/epw-derived-preliminary-climate/phases/phase-05-docs-downstream-and-release.md
@@ -20,6 +20,10 @@ claims, IronPython regressions, or downstream zero fallbacks.
    IronPython syntax/import compatibility check appropriate to this repo.
 5. Coordinate PHX/OpenPH behavior so `peak_loads=None` produces a targeted
    readiness diagnostic and never zero-filled load inputs.
+   - PHX audit target: `phx/from_HBJSON/create_variant.py:394-456` (blank PHPP
+     codes plus unconditional peak-load dereferences).
+   - OpenPH: no adjacent checkout was present during Phase 01; locate and audit
+     its current honeybee-ph climate ingestion path before release.
 6. Run focused tests, `python3 -m pytest` at or above the 75% repository
    coverage floor, Black, and `git diff --check`.
 7. Fold the stable provenance/readiness contract into `context/`, update

--- a/tests/test_honeybee_ph/test_site/epw_fixture.py
+++ b/tests/test_honeybee_ph/test_site/epw_fixture.py
@@ -6,7 +6,14 @@ month/day/hour indices within the test run.
 """
 
 from ladybug.epw import EPW
+from ladybug.analysisperiod import AnalysisPeriod
+from ladybug.datacollection import MonthlyCollection
+from ladybug.datatype.temperature import GroundTemperature
+from ladybug.header import Header
 from ladybug.location import Location
+
+
+_DEFAULT_GROUND = object()
 
 
 def write_synthetic_epw(
@@ -18,6 +25,7 @@ def write_synthetic_epw(
     opaque_sky_cover=5,
     is_leap_year=False,
     field_overrides=None,
+    ground_temperatures=_DEFAULT_GROUND,
 ):
     monthly_means = [float(month) for month in range(1, 13)] if monthly_means is None else monthly_means
     daily_ranges = [4.0] * 12 if daily_ranges is None else daily_ranges
@@ -72,6 +80,25 @@ def write_synthetic_epw(
         for index, value in overrides.items():
             values[index] = value
         fields[field_name].values = values
+
+    if ground_temperatures is _DEFAULT_GROUND:
+        ground_temperatures = {0.5: [10.0] * 12}
+    if ground_temperatures is not None:
+        ground_collections = {}
+        for depth, values in ground_temperatures.items():
+            header = Header(
+                GroundTemperature(),
+                "C",
+                AnalysisPeriod(),
+                {
+                    "depth": depth,
+                    "soil conductivity": "1.5",
+                    "soil density": "1800",
+                    "soil specific heat": "900",
+                },
+            )
+            ground_collections[depth] = MonthlyCollection(header, values, list(range(12)))
+        epw.monthly_ground_temperature = ground_collections
 
     epw.write(str(file_path))
     return file_path

--- a/tests/test_honeybee_ph/test_site/epw_fixture.py
+++ b/tests/test_honeybee_ph/test_site/epw_fixture.py
@@ -1,0 +1,77 @@
+"""Synthetic EPW generation for tests.
+
+The fixture contains no copied weather observations or certification climate
+data. Every hourly value is generated from controlled constants and calendar
+month/day/hour indices within the test run.
+"""
+
+from ladybug.epw import EPW
+from ladybug.location import Location
+
+
+def write_synthetic_epw(
+    file_path,
+    monthly_means=None,
+    daily_ranges=None,
+    wind_speed=3.0,
+    horizontal_infrared=300.0,
+    opaque_sky_cover=5,
+    is_leap_year=False,
+    field_overrides=None,
+):
+    monthly_means = [float(month) for month in range(1, 13)] if monthly_means is None else monthly_means
+    daily_ranges = [4.0] * 12 if daily_ranges is None else daily_ranges
+    field_overrides = {} if field_overrides is None else field_overrides
+
+    epw = EPW.from_missing_values(is_leap_year=is_leap_year)
+    epw.location = Location(
+        city="Synthetic Test City",
+        state="TS",
+        country="Synthetic",
+        latitude=42.25,
+        longitude=-73.35,
+        time_zone=-5.0,
+        elevation=321.0,
+        station_id="SYNTHETIC-001",
+        source="Generated test data",
+    )
+
+    dry_bulb = []
+    dewpoint = []
+    for dt in epw.dry_bulb_temperature.datetimes:
+        mean = monthly_means[dt.month - 1]
+        half_range = daily_ranges[dt.month - 1] / 2.0
+        offset = -half_range if dt.hour < 12 else half_range
+        dry_bulb.append(mean + offset)
+        dewpoint.append(mean - 5.0 + offset)
+
+    length = len(dry_bulb)
+    epw.dry_bulb_temperature.values = dry_bulb
+    epw.dew_point_temperature.values = dewpoint
+    epw.wind_speed.values = [wind_speed] * length
+    epw.horizontal_infrared_radiation_intensity.values = [
+        9999 if horizontal_infrared is None else horizontal_infrared
+    ] * length
+    epw.opaque_sky_cover.values = [opaque_sky_cover] * length
+    epw.global_horizontal_radiation.values = [100.0] * length
+    epw.direct_normal_radiation.values = [50.0] * length
+    epw.diffuse_horizontal_radiation.values = [50.0] * length
+
+    fields = {
+        "dry_bulb_temperature": epw.dry_bulb_temperature,
+        "dew_point_temperature": epw.dew_point_temperature,
+        "wind_speed": epw.wind_speed,
+        "horizontal_infrared_radiation_intensity": epw.horizontal_infrared_radiation_intensity,
+        "opaque_sky_cover": epw.opaque_sky_cover,
+        "global_horizontal_radiation": epw.global_horizontal_radiation,
+        "direct_normal_radiation": epw.direct_normal_radiation,
+        "diffuse_horizontal_radiation": epw.diffuse_horizontal_radiation,
+    }
+    for field_name, overrides in field_overrides.items():
+        values = list(fields[field_name].values)
+        for index, value in overrides.items():
+            values[index] = value
+        fields[field_name].values = values
+
+    epw.write(str(file_path))
+    return file_path

--- a/tests/test_honeybee_ph/test_site/test_climate/test_provenance_readiness.py
+++ b/tests/test_honeybee_ph/test_site/test_climate/test_provenance_readiness.py
@@ -1,0 +1,150 @@
+from copy import deepcopy
+
+import pytest
+
+from honeybee_ph import site
+
+
+def _available_provenance(**overrides):
+    values = {
+        "source_type": "user_defined",
+        "source_name": "Test climate",
+        "monthly_data_available": True,
+        "peak_load_data_available": True,
+        "assumptions": {"method": {"name": "controlled-values"}},
+    }
+    values.update(overrides)
+    return site.ClimateProvenance(**values)
+
+
+def test_climate_provenance_round_trip_preserves_unknown_flags():
+    provenance = site.ClimateProvenance(
+        source_type="legacy_unknown",
+        source_uri=None,
+        is_certification_approved=None,
+        monthly_data_available=None,
+        peak_load_data_available=None,
+        assumptions={"note": "availability not supplied"},
+    )
+
+    restored = site.ClimateProvenance.from_dict(provenance.to_dict())
+
+    assert restored.to_dict() == provenance.to_dict()
+    assert restored.is_certification_approved is None
+    assert restored.monthly_data_available is None
+    assert restored.peak_load_data_available is None
+
+
+def test_climate_provenance_rejects_unknown_source_type():
+    with pytest.raises(ValueError, match="source_type"):
+        site.ClimateProvenance(source_type="weather-ish")
+
+
+def test_default_climate_serialization_remains_legacy_compatible():
+    serialized = site.Climate().to_dict()
+
+    assert "provenance" not in serialized
+    assert isinstance(serialized["peak_loads"], dict)
+
+    restored = site.Climate.from_dict(deepcopy(serialized))
+    assert restored.provenance is None
+    assert restored.to_dict() == serialized
+
+
+def test_missing_peak_loads_keeps_legacy_default_but_null_round_trips():
+    legacy = site.Climate().to_dict()
+    legacy.pop("peak_loads")
+
+    legacy_restored = site.Climate.from_dict(legacy)
+    assert isinstance(legacy_restored.peak_loads, site.Climate_PeakLoadCollection)
+
+    unavailable = site.Climate(
+        _peak_loads=None,
+        _provenance=_available_provenance(peak_load_data_available=False),
+    )
+    serialized = unavailable.to_dict()
+    restored = site.Climate.from_dict(serialized)
+
+    assert serialized["peak_loads"] is None
+    assert restored.peak_loads is None
+    assert restored.to_dict() == serialized
+
+
+def test_climate_duplicate_recursively_copies_provenance_and_children():
+    original = site.Climate(_provenance=_available_provenance())
+    duplicate = original.duplicate()
+
+    assert duplicate.to_dict() == original.to_dict()
+    assert duplicate.provenance is not original.provenance
+    assert duplicate.provenance.assumptions is not original.provenance.assumptions
+    assert duplicate.provenance.assumptions["method"] is not original.provenance.assumptions["method"]
+    assert duplicate.monthly_temps is not original.monthly_temps
+    assert duplicate.monthly_radiation is not original.monthly_radiation
+    assert duplicate.peak_loads is not original.peak_loads
+
+
+def test_monthly_readiness_uses_availability_not_numeric_truthiness():
+    climate = site.Climate(_provenance=_available_provenance())
+
+    assert climate.monthly_demand_readiness_issues() == []
+    assert climate.is_monthly_demand_ready is True
+
+    climate.monthly_temps.ground_temps.march = None
+    assert climate.monthly_demand_readiness_issues() == [
+        "monthly_temps.ground_temps.march: expected a finite numeric value; got None."
+    ]
+    assert climate.is_monthly_demand_ready is False
+
+
+def test_monthly_readiness_accumulates_non_real_values_as_issues():
+    climate = site.Climate(_provenance=_available_provenance())
+    climate.station_elevation = complex(1, 2)
+    climate.monthly_temps.air_temps.january = float("nan")
+
+    assert climate.monthly_demand_readiness_issues() == [
+        "station_elevation: expected a finite numeric value; got (1+2j).",
+        "monthly_temps.air_temps.january: expected a finite numeric value; got nan.",
+    ]
+
+
+def test_legacy_and_unavailable_monthly_readiness_are_distinct():
+    legacy = site.Climate()
+    unavailable = site.Climate(
+        _provenance=_available_provenance(monthly_data_available=False),
+    )
+
+    assert legacy.monthly_demand_readiness_issues() == [
+        "provenance: monthly climate data availability is unknown for this legacy climate."
+    ]
+    assert unavailable.monthly_demand_readiness_issues() == [
+        "provenance.monthly_data_available: monthly climate data is explicitly unavailable."
+    ]
+
+
+def test_peak_readiness_reports_specialized_data_requirement():
+    climate = site.Climate(
+        _peak_loads=None,
+        _provenance=_available_provenance(peak_load_data_available=False),
+    )
+
+    assert climate.peak_load_readiness_issues() == [
+        "provenance.peak_load_data_available: approved or specialized peak-load climate data must be supplied separately."
+    ]
+    assert climate.is_peak_load_ready is False
+
+
+def test_peak_readiness_accepts_explicit_zero_values():
+    climate = site.Climate(_provenance=_available_provenance())
+
+    assert climate.peak_load_readiness_issues() == []
+    assert climate.is_peak_load_ready is True
+
+
+def test_blank_phpp_codes_serialize_without_library_identity():
+    codes = site.PHPPCodes.blank()
+
+    assert codes.country_code == ""
+    assert codes.region_code == ""
+    assert codes.dataset_name == ""
+    assert codes.to_dict()["display_name"] == ""
+    assert site.PHPPCodes.from_dict(codes.to_dict()).to_dict() == codes.to_dict()

--- a/tests/test_honeybee_ph/test_site/test_epw_conversion.py
+++ b/tests/test_honeybee_ph/test_site/test_epw_conversion.py
@@ -1,7 +1,10 @@
 import hashlib
+import math
 
 import pytest
+from ladybug.epw import EPW
 from ladybug.skymodel import calc_horizontal_infrared, calc_sky_temperature
+from ladybug.wea import Wea
 
 from honeybee_ph._epw import convert_epw
 from tests.test_honeybee_ph.test_site.epw_fixture import write_synthetic_epw
@@ -282,3 +285,189 @@ def test_checksum_and_conversion_metadata_are_deterministic(tmp_path):
     assert first.provenance.conversion_method == second.provenance.conversion_method
     assert first.provenance.conversion_method_version == second.provenance.conversion_method_version
     assert first.monthly_air_temperatures == second.monthly_air_temperatures
+
+
+def _monthly_totals_kwh(collection):
+    monthly = [[] for _ in range(12)]
+    for value, dt in zip(collection.values, collection.datetimes):
+        monthly[dt.month - 1].append(value)
+    return [sum(values) / 1000.0 for values in monthly]
+
+
+def test_global_and_cardinal_radiation_match_ladybug_reference(tmp_path):
+    epw_path = write_synthetic_epw(tmp_path / "radiation.epw")
+
+    result = convert_epw(str(epw_path))
+    epw = EPW(str(epw_path))
+    wea = Wea(epw.location, epw.direct_normal_radiation, epw.diffuse_horizontal_radiation)
+
+    assert result.issues == []
+    assert result.monthly_global_radiation == pytest.approx(_monthly_totals_kwh(epw.global_horizontal_radiation))
+    for field_name, azimuth in (
+        ("monthly_north_radiation", 0),
+        ("monthly_east_radiation", 90),
+        ("monthly_south_radiation", 180),
+        ("monthly_west_radiation", 270),
+    ):
+        reference = wea.directional_irradiance(
+            altitude=0,
+            azimuth=azimuth,
+            ground_reflectance=0.2,
+            isotropic=True,
+        )[0]
+        assert getattr(result, field_name) == pytest.approx(_monthly_totals_kwh(reference))
+
+
+def test_radiation_options_change_results_and_are_recorded(tmp_path):
+    epw_path = write_synthetic_epw(tmp_path / "radiation-options.epw")
+
+    baseline = convert_epw(str(epw_path), ground_reflectance=0.1, diffuse_model="isotropic")
+    reflected = convert_epw(str(epw_path), ground_reflectance=0.6, diffuse_model="isotropic")
+    anisotropic = convert_epw(str(epw_path), ground_reflectance=0.1, diffuse_model="anisotropic")
+
+    assert baseline.issues == []
+    assert reflected.issues == []
+    assert anisotropic.issues == []
+    assert baseline.monthly_north_radiation != reflected.monthly_north_radiation
+    assert baseline.monthly_north_radiation != anisotropic.monthly_north_radiation
+    assert baseline.provenance.assumptions["ground_reflectance"] == 0.1
+    assert baseline.provenance.assumptions["diffuse_model"] == "isotropic"
+    assert reflected.provenance.assumptions["ground_reflectance"] == 0.6
+    assert reflected.provenance.assumptions["diffuse_model"] == "isotropic"
+    assert anisotropic.provenance.assumptions["ground_reflectance"] == 0.1
+    assert anisotropic.provenance.assumptions["diffuse_model"] == "anisotropic"
+
+
+@pytest.mark.parametrize(
+    "ground_reflectance, diffuse_model, expected_field",
+    [
+        (-0.1, "isotropic", "ground_reflectance"),
+        (1.1, "isotropic", "ground_reflectance"),
+        (0.2, "perez", "diffuse_model"),
+    ],
+)
+def test_invalid_radiation_options_are_targeted(tmp_path, ground_reflectance, diffuse_model, expected_field):
+    epw_path = write_synthetic_epw(tmp_path / "invalid-options.epw")
+
+    result = convert_epw(
+        str(epw_path),
+        ground_reflectance=ground_reflectance,
+        diffuse_model=diffuse_model,
+    )
+
+    assert len(result.issues) == 1
+    assert expected_field in result.issues[0]
+    assert expected_field not in result.provenance.assumptions
+
+
+@pytest.mark.parametrize("ground_temperature_depth", [-0.1, float("nan"), True, "deep"])
+def test_invalid_ground_temperature_depth_is_targeted(tmp_path, ground_temperature_depth):
+    epw_path = write_synthetic_epw(tmp_path / "invalid-ground-depth.epw")
+
+    result = convert_epw(str(epw_path), ground_temperature_depth=ground_temperature_depth)
+
+    assert len(result.issues) == 1
+    assert "ground_temperature_depth" in result.issues[0]
+    assert "ground_temperature_depth_m" not in result.provenance.assumptions
+
+
+def test_single_ground_series_is_selected_automatically(tmp_path):
+    ground_values = [float(value) for value in range(12)]
+    epw_path = write_synthetic_epw(
+        tmp_path / "one-ground.epw",
+        ground_temperatures={0.5: ground_values},
+    )
+
+    result = convert_epw(str(epw_path))
+
+    assert result.issues == []
+    assert result.ground_temperature_depth == 0.5
+    assert result.monthly_ground_temperatures == ground_values
+    assert result.provenance.assumptions["ground_temperature_depth_m"] == 0.5
+
+
+def test_no_ground_series_is_explicitly_unavailable(tmp_path):
+    epw_path = write_synthetic_epw(tmp_path / "no-ground.epw", ground_temperatures=None)
+
+    result = convert_epw(str(epw_path))
+
+    assert result.monthly_ground_temperatures is None
+    assert result.issues == [
+        "{}: ground_temperature: EPW header contains no monthly ground-temperature series.".format(epw_path)
+    ]
+    assert result.provenance.monthly_data_available is False
+
+
+def test_multiple_ground_series_requires_an_explicit_depth(tmp_path):
+    ground = {0.5: [10.0] * 12, 2.0: [12.0] * 12}
+    epw_path = write_synthetic_epw(tmp_path / "multiple-ground.epw", ground_temperatures=ground)
+
+    ambiguous = convert_epw(str(epw_path))
+    selected = convert_epw(str(epw_path), ground_temperature_depth=2.0)
+    unavailable = convert_epw(str(epw_path), ground_temperature_depth=1.0)
+
+    assert ambiguous.issues == [
+        "{}: ground_temperature_depth: EPW header has multiple series; choose one of [0.5, 2.0] m.".format(epw_path)
+    ]
+    assert selected.issues == []
+    assert selected.ground_temperature_depth == 2.0
+    assert selected.monthly_ground_temperatures == [12.0] * 12
+    assert unavailable.issues == [
+        "{}: ground_temperature_depth: requested 1.0 m; available depths are [0.5, 2.0] m.".format(epw_path)
+    ]
+
+
+def test_invalid_ground_month_is_targeted(tmp_path):
+    ground = {0.5: [10.0] * 11 + [float("nan")]}
+    epw_path = write_synthetic_epw(tmp_path / "invalid-ground.epw", ground_temperatures=ground)
+
+    result = convert_epw(str(epw_path))
+
+    assert result.monthly_ground_temperatures is None
+    assert "ground_temperature depth 0.5 m december" in result.issues[0]
+    assert "observed nan" in result.issues[0]
+
+
+def test_missing_radiation_is_not_converted_to_zero(tmp_path):
+    epw_path = write_synthetic_epw(
+        tmp_path / "missing-radiation.epw",
+        field_overrides={
+            "global_horizontal_radiation": {0: 9999},
+            "direct_normal_radiation": {1: 9999},
+            "diffuse_horizontal_radiation": {2: -1},
+        },
+    )
+
+    result = convert_epw(str(epw_path))
+
+    assert len(result.issues) == 3
+    assert "global_horizontal_radiation hour 1" in result.issues[0]
+    assert "direct_normal_radiation hour 2" in result.issues[1]
+    assert "diffuse_horizontal_radiation hour 3" in result.issues[2]
+    assert result.monthly_global_radiation is None
+    assert result.monthly_north_radiation is None
+
+
+def test_complete_monthly_outputs_have_twelve_finite_values(tmp_path):
+    epw_path = write_synthetic_epw(tmp_path / "complete-monthly.epw")
+
+    result = convert_epw(str(epw_path))
+
+    output_names = (
+        "monthly_air_temperatures",
+        "monthly_dewpoint_temperatures",
+        "monthly_sky_temperatures",
+        "monthly_ground_temperatures",
+        "monthly_north_radiation",
+        "monthly_east_radiation",
+        "monthly_south_radiation",
+        "monthly_west_radiation",
+        "monthly_global_radiation",
+    )
+    assert result.issues == []
+    assert result.provenance.monthly_data_available is True
+    assert result.provenance.peak_load_data_available is False
+    for output_name in output_names:
+        values = getattr(result, output_name)
+        assert len(values) == 12
+        assert all(math.isfinite(value) for value in values)

--- a/tests/test_honeybee_ph/test_site/test_epw_conversion.py
+++ b/tests/test_honeybee_ph/test_site/test_epw_conversion.py
@@ -1,0 +1,284 @@
+import hashlib
+
+import pytest
+from ladybug.skymodel import calc_horizontal_infrared, calc_sky_temperature
+
+from honeybee_ph._epw import convert_epw
+from tests.test_honeybee_ph.test_site.epw_fixture import write_synthetic_epw
+
+
+def test_epw_location_temperature_scalars_and_provenance(tmp_path):
+    epw_path = write_synthetic_epw(tmp_path / "controlled.epw")
+
+    result = convert_epw(str(epw_path))
+
+    assert result.issues == []
+    assert result.location_name == "Synthetic Test City"
+    assert result.latitude == 42.25
+    assert result.longitude == -73.35
+    assert result.elevation == 321.0
+    assert result.utc_offset == -5.0
+    assert result.monthly_air_temperatures == pytest.approx(list(range(1, 13)))
+    assert result.monthly_dewpoint_temperatures == pytest.approx(list(range(-4, 8)))
+    assert result.monthly_sky_temperatures == pytest.approx([calc_sky_temperature(300.0)] * 12)
+    assert result.average_wind_speed == pytest.approx(3.0)
+    assert result.summer_daily_temperature_swing == pytest.approx(4.0)
+    assert result.source_checksum == hashlib.sha256(epw_path.read_bytes()).hexdigest()
+    assert result.provenance.source_checksum == result.source_checksum
+    assert result.provenance.source_type == "epw_derived"
+    assert result.provenance.source_uri == str(epw_path)
+    assert result.provenance.conversion_method == "ladybug_epw_preliminary_monthly"
+    assert result.provenance.conversion_method_version == "1"
+    assert result.provenance.is_certification_approved is False
+    assert result.provenance.assumptions["summer_daily_temperature_swing"] == (
+        "mean daily dry-bulb range over the warmest three consecutive calendar months"
+    )
+
+
+def test_southern_warm_season_wraps_across_year_end(tmp_path):
+    monthly_means = [30.0, 29.0, 5.0, 4.0, 3.0, 2.0, 1.0, 2.0, 3.0, 4.0, 5.0, 28.0]
+    daily_ranges = [2.0, 4.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 12.0]
+    epw_path = write_synthetic_epw(
+        tmp_path / "southern.epw",
+        monthly_means=monthly_means,
+        daily_ranges=daily_ranges,
+    )
+
+    result = convert_epw(str(epw_path))
+
+    expected = ((31 * 2.0) + (28 * 4.0) + (31 * 12.0)) / 90.0
+    assert result.issues == []
+    assert result.summer_daily_temperature_swing == pytest.approx(expected)
+    assert result.provenance.assumptions["warmest_consecutive_months"] == [12, 1, 2]
+
+
+def test_leap_year_is_accepted_as_complete_annual_series(tmp_path):
+    epw_path = write_synthetic_epw(tmp_path / "leap.epw", is_leap_year=True)
+
+    result = convert_epw(str(epw_path))
+
+    assert result.issues == []
+    assert len(result.monthly_air_temperatures) == 12
+
+
+def test_partial_year_reports_hourly_cardinality(tmp_path):
+    epw_path = write_synthetic_epw(tmp_path / "partial.epw")
+    lines = epw_path.read_text().splitlines()
+    epw_path.write_text("\n".join(lines[:-1]) + "\n")
+
+    result = convert_epw(str(epw_path))
+
+    assert result.issues == [
+        "{}: hourly_data: expected 8760 hourly rows for a non-leap year; got 8759.".format(epw_path)
+    ]
+
+
+def test_malformed_epw_and_missing_path_return_targeted_issues(tmp_path):
+    malformed = tmp_path / "malformed.epw"
+    malformed.write_text("not an EPW\n")
+    missing = tmp_path / "missing.epw"
+
+    malformed_result = convert_epw(str(malformed))
+    missing_result = convert_epw(str(missing))
+
+    assert malformed_result.issues == [
+        "{}: header: expected at least 8 EPW header lines and hourly data; got 1 total lines.".format(malformed)
+    ]
+    assert missing_result.issues[0].startswith("{}: file: unable to read EPW".format(missing))
+
+
+def test_non_utf8_epw_returns_targeted_issue(tmp_path):
+    epw_path = tmp_path / "binary.epw"
+    epw_path.write_bytes(b"\xff\xfe\x00\x80")
+
+    result = convert_epw(str(epw_path))
+
+    assert result.issues[0].startswith("{}: file: EPW is not valid UTF-8 text".format(epw_path))
+
+
+def test_invalid_location_header_and_leap_flag_are_targeted(tmp_path):
+    bad_location = write_synthetic_epw(tmp_path / "bad-location-header.epw")
+    lines = bad_location.read_text().splitlines()
+    lines[0] = "NOT-LOCATION"
+    bad_location.write_text("\n".join(lines) + "\n")
+
+    bad_leap = write_synthetic_epw(tmp_path / "bad-leap.epw")
+    lines = bad_leap.read_text().splitlines()
+    leap_header = lines[4].split(",")
+    leap_header[1] = "Maybe"
+    lines[4] = ",".join(leap_header)
+    bad_leap.write_text("\n".join(lines) + "\n")
+
+    assert convert_epw(str(bad_location)).issues == [
+        "{}: location: expected a 10-field EPW LOCATION header.".format(bad_location)
+    ]
+    assert convert_epw(str(bad_leap)).issues == [
+        "{}: header.is_leap_year: expected 'Yes' or 'No'; observed 'Maybe'.".format(bad_leap)
+    ]
+
+
+def test_non_numeric_location_value_is_targeted(tmp_path):
+    epw_path = write_synthetic_epw(tmp_path / "non-numeric-location.epw")
+    lines = epw_path.read_text().splitlines()
+    location = lines[0].split(",")
+    location[6] = "north"
+    lines[0] = ",".join(location)
+    epw_path.write_text("\n".join(lines) + "\n")
+
+    result = convert_epw(str(epw_path))
+
+    assert result.issues == ["{}: location.latitude: expected a finite number; observed 'north'.".format(epw_path)]
+
+
+def test_missing_and_non_finite_fields_accumulate_without_zero_fallback(tmp_path):
+    epw_path = write_synthetic_epw(
+        tmp_path / "invalid-values.epw",
+        field_overrides={
+            "dry_bulb_temperature": {0: 99.9},
+            "dew_point_temperature": {1: float("nan")},
+            "wind_speed": {2: float("inf")},
+        },
+    )
+
+    result = convert_epw(str(epw_path))
+
+    assert len(result.issues) == 3
+    assert "dry_bulb_temperature hour 1" in result.issues[0]
+    assert "missing sentinel 99.9" in result.issues[0]
+    assert "dew_point_temperature hour 2" in result.issues[1]
+    assert "observed nan" in result.issues[1]
+    assert "wind_speed hour 3" in result.issues[2]
+    assert "observed inf" in result.issues[2]
+    assert result.monthly_air_temperatures is None
+    assert result.monthly_dewpoint_temperatures is None
+    assert result.average_wind_speed is None
+
+
+def test_bad_location_fields_accumulate_before_ladybug_parse(tmp_path):
+    epw_path = write_synthetic_epw(tmp_path / "bad-location.epw")
+    lines = epw_path.read_text().splitlines()
+    location = lines[0].split(",")
+    location[6:10] = ["91", "181", "15", "nan"]
+    lines[0] = ",".join(location)
+    epw_path.write_text("\n".join(lines) + "\n")
+
+    result = convert_epw(str(epw_path))
+
+    assert len(result.issues) == 4
+    assert "location.latitude" in result.issues[0]
+    assert "location.longitude" in result.issues[1]
+    assert "location.utc_offset" in result.issues[2]
+    assert "location.elevation" in result.issues[3]
+
+
+def test_out_of_range_hourly_values_accumulate(tmp_path):
+    epw_path = write_synthetic_epw(
+        tmp_path / "out-of-range.epw",
+        field_overrides={
+            "dry_bulb_temperature": {0: -71.0},
+            "dew_point_temperature": {1: 71.0},
+            "wind_speed": {2: 41.0},
+        },
+    )
+
+    result = convert_epw(str(epw_path))
+
+    assert len(result.issues) == 3
+    assert "expected -70.0 through 70.0; observed -71.0" in result.issues[0]
+    assert "expected -70.0 through 70.0; observed 71.0" in result.issues[1]
+    assert "expected 0.0 through 40.0; observed 41.0" in result.issues[2]
+
+
+@pytest.mark.parametrize(
+    "horizontal_ir, opaque_sky, expected_field",
+    [
+        (float("nan"), 5, "horizontal_infrared_radiation_intensity"),
+        (float("inf"), 5, "horizontal_infrared_radiation_intensity"),
+        (-1.0, 5, "horizontal_infrared_radiation_intensity"),
+        (None, 99, "opaque_sky_cover"),
+    ],
+)
+def test_invalid_sky_source_values_are_targeted(tmp_path, horizontal_ir, opaque_sky, expected_field):
+    epw_path = write_synthetic_epw(
+        tmp_path / "invalid-sky.epw",
+        horizontal_infrared=horizontal_ir,
+        opaque_sky_cover=opaque_sky,
+    )
+
+    result = convert_epw(str(epw_path))
+
+    assert result.monthly_sky_temperatures is None
+    assert expected_field in result.issues[0]
+
+
+def test_missing_horizontal_ir_cannot_fallback_from_invalid_temperature(tmp_path):
+    epw_path = write_synthetic_epw(
+        tmp_path / "fallback-missing-source.epw",
+        horizontal_infrared=None,
+        field_overrides={"dry_bulb_temperature": {0: 99.9}},
+    )
+
+    result = convert_epw(str(epw_path))
+
+    assert len(result.issues) == 1
+    assert "dry_bulb_temperature hour 1" in result.issues[0]
+    assert result.monthly_sky_temperatures is None
+
+
+def test_ladybug_parse_error_is_returned_as_issue(tmp_path):
+    epw_path = write_synthetic_epw(tmp_path / "parse-error.epw")
+    lines = epw_path.read_text().splitlines()
+    first_hour = lines[8].split(",")
+    first_hour[6] = "not-a-temperature"
+    lines[8] = ",".join(first_hour)
+    epw_path.write_text("\n".join(lines) + "\n")
+
+    result = convert_epw(str(epw_path))
+
+    assert len(result.issues) == 1
+    assert "epw: Ladybug failed to parse the file" in result.issues[0]
+
+
+@pytest.mark.parametrize("first_hour", ["too,few,fields", None])
+def test_horizontal_ir_preflight_defers_structural_errors_to_ladybug(tmp_path, first_hour):
+    epw_path = write_synthetic_epw(tmp_path / "structural-error.epw")
+    lines = epw_path.read_text().splitlines()
+    if first_hour is None:
+        fields = lines[8].split(",")
+        fields[12] = "not-infrared"
+        lines[8] = ",".join(fields)
+    else:
+        lines[8] = first_hour
+    epw_path.write_text("\n".join(lines) + "\n")
+
+    result = convert_epw(str(epw_path))
+
+    assert len(result.issues) == 1
+    assert "epw: Ladybug failed to parse the file" in result.issues[0]
+
+
+def test_sky_temperature_uses_ladybug_horizontal_infrared_fallback(tmp_path):
+    epw_path = write_synthetic_epw(tmp_path / "sky-fallback.epw", horizontal_infrared=None)
+
+    result = convert_epw(str(epw_path))
+
+    cold_sky = calc_sky_temperature(calc_horizontal_infrared(5, -1.0, -6.0))
+    warm_sky = calc_sky_temperature(calc_horizontal_infrared(5, 3.0, -2.0))
+    expected_sky = (cold_sky + warm_sky) / 2.0
+    assert result.issues == []
+    assert result.monthly_sky_temperatures[0] == pytest.approx(expected_sky)
+    assert result.provenance.assumptions["sky_temperature"] == (
+        "ladybug EPW.sky_temperature with horizontal-infrared fallback from opaque sky cover"
+    )
+
+
+def test_checksum_and_conversion_metadata_are_deterministic(tmp_path):
+    epw_path = write_synthetic_epw(tmp_path / "deterministic.epw")
+
+    first = convert_epw(str(epw_path))
+    second = convert_epw(str(epw_path))
+
+    assert first.source_checksum == second.source_checksum
+    assert first.provenance.conversion_method == second.provenance.conversion_method
+    assert first.provenance.conversion_method_version == second.provenance.conversion_method_version
+    assert first.monthly_air_temperatures == second.monthly_air_temperatures

--- a/tests/test_honeybee_ph/test_site/test_site_from_epw.py
+++ b/tests/test_honeybee_ph/test_site/test_site_from_epw.py
@@ -1,0 +1,137 @@
+import json
+
+import pytest
+
+from honeybee_ph.bldg_segment import BldgSegment
+from honeybee_ph.properties.room import RoomPhProperties
+from honeybee_ph.site import Site
+from tests.test_honeybee_ph.test_site.epw_fixture import write_synthetic_epw
+
+
+def test_site_from_epw_builds_complete_preliminary_monthly_climate(tmp_path):
+    epw_path = write_synthetic_epw(tmp_path / "site.epw")
+
+    site = Site.from_epw(str(epw_path))
+
+    assert site.location.display_name == "Synthetic Test City"
+    assert site.location.latitude == 42.25
+    assert site.location.longitude == -73.35
+    assert site.location.site_elevation == 321.0
+    assert site.location.climate_zone is None
+    assert site.location.hours_from_UTC == -5.0
+    assert site.climate.display_name == "Synthetic Test City"
+    assert site.climate.station_elevation == 321.0
+    assert site.climate.monthly_temps.air_temps.values == pytest.approx(list(range(1, 13)))
+    assert site.climate.monthly_temps.ground_temps.values == [10.0] * 12
+    assert len(site.climate.monthly_radiation.north.values) == 12
+    assert site.climate.peak_loads is None
+    assert site.climate.provenance.source_type == "epw_derived"
+    assert site.climate.provenance.is_certification_approved is False
+    assert site.climate.is_monthly_demand_ready is True
+    assert site.climate.is_peak_load_ready is False
+    assert site.climate.peak_load_readiness_issues() == [
+        "provenance.peak_load_data_available: approved or specialized peak-load climate data must be supplied separately."
+    ]
+    assert site.phpp_library_codes.country_code == ""
+    assert site.phpp_library_codes.region_code == ""
+    assert site.phpp_library_codes.dataset_name == ""
+    assert "US0055c-New York" not in json.dumps(site.to_dict())
+
+
+def test_site_from_epw_round_trip_and_duplicate_are_independent(tmp_path):
+    epw_path = write_synthetic_epw(tmp_path / "round-trip.epw")
+    first = Site.from_epw(str(epw_path))
+
+    encoded = json.dumps(first.to_dict(), allow_nan=False)
+    round_tripped = Site.from_dict(json.loads(encoded))
+    duplicated = first.duplicate()
+    second = Site.from_epw(str(epw_path))
+
+    assert round_tripped.to_dict() == first.to_dict()
+    assert duplicated.to_dict() == first.to_dict()
+    assert second.climate.monthly_temps.air_temps.values == first.climate.monthly_temps.air_temps.values
+    assert second.climate.monthly_radiation.north.values == first.climate.monthly_radiation.north.values
+    assert second.climate.provenance.source_checksum == first.climate.provenance.source_checksum
+    assert second.climate.provenance.conversion_method == first.climate.provenance.conversion_method
+    for candidate in (round_tripped, duplicated, second):
+        assert candidate is not first
+        assert candidate.location is not first.location
+        assert candidate.climate is not first.climate
+        assert candidate.climate.monthly_temps is not first.climate.monthly_temps
+        assert candidate.climate.monthly_temps.air_temps is not first.climate.monthly_temps.air_temps
+        assert candidate.climate.monthly_radiation is not first.climate.monthly_radiation
+        assert candidate.climate.monthly_radiation.north is not first.climate.monthly_radiation.north
+        assert candidate.climate.ground is not first.climate.ground
+        assert candidate.climate.provenance is not first.climate.provenance
+        assert candidate.climate.provenance.assumptions is not first.climate.provenance.assumptions
+        assert candidate.phpp_library_codes is not first.phpp_library_codes
+
+    duplicated.climate.monthly_temps.air_temps.january = -99.0
+    duplicated.climate.monthly_radiation.north.january = -99.0
+    duplicated.climate.ground.ground_thermal_conductivity = -99.0
+    duplicated.climate.provenance.assumptions["mutated"] = True
+    assert first.climate.monthly_temps.air_temps.january == 1.0
+    assert first.climate.monthly_radiation.north.january != -99.0
+    assert first.climate.ground.ground_thermal_conductivity == 2
+    assert "mutated" not in first.climate.provenance.assumptions
+
+
+def test_site_from_epw_forwards_conversion_options(tmp_path):
+    epw_path = write_synthetic_epw(
+        tmp_path / "options.epw",
+        ground_temperatures={0.5: [10.0] * 12, 2.0: [12.0] * 12},
+    )
+
+    site = Site.from_epw(
+        str(epw_path),
+        ground_temperature_depth=2.0,
+        ground_reflectance=0.6,
+        diffuse_model="anisotropic",
+    )
+
+    assert site.climate.monthly_temps.ground_temps.values == [12.0] * 12
+    assert site.climate.provenance.assumptions["ground_temperature_depth_m"] == 2.0
+    assert site.climate.provenance.assumptions["ground_reflectance"] == 0.6
+    assert site.climate.provenance.assumptions["diffuse_model"] == "anisotropic"
+
+
+def test_epw_site_survives_building_segment_and_room_property_paths(tmp_path):
+    epw_path = write_synthetic_epw(tmp_path / "host-paths.epw")
+    segment = BldgSegment()
+    segment.site = Site.from_epw(str(epw_path))
+
+    segment_round_trip = BldgSegment.from_dict(segment.to_dict())
+    segment_duplicate = segment.duplicate()
+    room_properties = RoomPhProperties(_host=None)
+    room_properties.ph_bldg_segment = segment
+    room_round_trip = RoomPhProperties.from_dict(room_properties.to_dict()["ph"], host=None)
+    room_duplicate = room_properties.duplicate()
+
+    for candidate in (
+        segment_round_trip.site,
+        segment_duplicate.site,
+        room_round_trip.ph_bldg_segment.site,
+        room_duplicate.ph_bldg_segment.site,
+    ):
+        assert candidate.to_dict() == segment.site.to_dict()
+        assert candidate is not segment.site
+        assert candidate.climate.provenance is not segment.site.climate.provenance
+
+
+def test_site_from_epw_raises_one_error_with_accumulated_issues(tmp_path):
+    epw_path = write_synthetic_epw(
+        tmp_path / "invalid.epw",
+        field_overrides={
+            "dry_bulb_temperature": {0: 99.9},
+            "wind_speed": {1: 999},
+        },
+    )
+
+    with pytest.raises(ValueError) as error:
+        Site.from_epw(str(epw_path))
+
+    message = str(error.value)
+    assert "EPW conversion failed" in message
+    assert str(epw_path) in message
+    assert "dry_bulb_temperature hour 1" in message
+    assert "wind_speed hour 2" in message


### PR DESCRIPTION
## Summary
- add explicit climate provenance and monthly/peak readiness contracts
- derive preliminary monthly temperature, radiation, wind, and ground-temperature values from a single EPW snapshot
- add `Site.from_epw(...)`, synthetic-fixture coverage, and public documentation
- preserve certification boundaries: no PHPP codes, climate zone, or peak-load dataset are inferred

## Verification
- `pytest`: 966 passed, 80% aggregate coverage
- Black clean
- Python 2 grammar parse clean for changed runtime modules
- sdist/wheel build clean; no EPW or copied climate dataset included
- built-wheel EPW smoke: monthly ready, peak not ready, provenance `epw_derived`

## Downstream
- PHX readiness guard is prepared on `codex/epw-derived-preliminary-climate-readiness`; its dependency floor will be pinned to this published honeybee-ph release before merge.