### PR TITLE
Add explicit balanced ventilation-system factory

### DIFF
--- a/context/decisions/0006-explicit-ventilation-system-states.md
+++ b/context/decisions/0006-explicit-ventilation-system-states.md
@@ -1,0 +1,56 @@
+# 0006 — Use Explicit Ventilation-System States and Selected Equipment
+
+**Date:** 2026-08-14
+**Status:** DECIDED
+**Decider:** Ed May
+**Research:** [`planning/features/default-ventilation-system-factory/`](../../planning/features/default-ventilation-system-factory/README.md)
+
+## Context
+
+The ph-modeler POC composed a bare `Ventilator()` with one default 1 m supply
+duct and one default 1 m exhaust duct to satisfy downstream conversion. That
+graph looked like a balanced HRV but encoded zero sensible recovery plus
+invented exterior duct geometry. Absence also crossed repository boundaries as
+numeric ID `0`, which blurred no assignment with a real device reference.
+
+Existing Honeybee-PH summer-window ACH inputs describe summer ventilation.
+They are not an authoritative source representation for PHPP's primary K12=3
+“Only window ventilation” mode.
+
+## Decision
+
+1. Represent no mechanical ventilation as `None` on Room HVAC properties. Do
+   not create a placeholder system or device ID.
+2. Construct balanced HRV/ERV systems with
+   `PhVentilationSystem.balanced_hrv()` from a selected `Ventilator` whose
+   recovery and electric-efficiency values are explicit and valid.
+3. Treat zero exterior duct elements as a valid, lossless state. When exterior
+   ducts exist, preserve every typed element and segment through HBJSON and PHX
+   to the PHPP calculation boundary.
+4. Keep summer-window ACH independent from the primary mechanical state. Do
+   not infer PHPP K12=3 until an authoritative upstream source state is
+   designed.
+5. Keep absence as `None` in Honeybee-PH and PHX. Numeric `0` is permitted only
+   in target-format adapters that require the legacy value and as temporary
+   OpenPH input compatibility.
+6. Do not add `preliminary_balanced_hrv()` without a separately accepted,
+   cited assumption set for recovery, fan power, frost protection, unit
+   location, exterior ducts, and provenance labeling.
+
+## Rationale
+
+- A constructor should validate known design intent, not disguise missing
+  selections as plausible equipment.
+- Empty exterior-duct collections are physically meaningful for a unit wholly
+  within the thermal envelope.
+- Multiple exterior duct elements contribute independently to the PHPP duct
+  efficiency exponent and cannot be collapsed without losing information.
+- Target-specific null aliases belong at serialization/export boundaries, not
+  in the source domain model.
+
+## What would reopen this
+
+- A supported source model is accepted for primary window-only ventilation.
+- Ed accepts a complete, cited preliminary HRV/ERV assumption set.
+- A target format removes its numeric no-assignment convention, allowing the
+  corresponding boundary adapter to drop `0`.

--- a/context/decisions/README.md
+++ b/context/decisions/README.md
@@ -15,3 +15,4 @@ research (e.g. `planning/refactor/`).
 | [0003](0003-psi-install-is-aperture-instance-data.md) | Psi-install is aperture-instance data resolved from named Install Types — never a reason to duplicate a window construction | Decided 2026-08-12 |
 | [0004](0004-no-bundled-licensed-climate-data.md) | Do not bundle licensed PHI/Phius climate datasets; convert user-supplied EPW data as explicitly preliminary instead | Decided 2026-08-14 |
 | [0005](0005-repository-coverage-floor-is-75-percent.md) | Enforce a truthful 75% repository-wide coverage floor while retaining focused contract tests for new behavior | Decided 2026-08-14 |
+| [0006](0006-explicit-ventilation-system-states.md) | Use explicit ventilation-system states and selected equipment; do not invent nominal HRV performance or ducts | Decided 2026-08-14 |

--- a/docs/nav.yml
+++ b/docs/nav.yml
@@ -2,6 +2,7 @@ nav:
   - Getting Started:
     - Overview: getting-started.md
     - EPW preliminary climate: epw-preliminary-climate.md
+    - Ventilation systems: ventilation-systems.md
   - Packages:
     - Overview: packages.md
   - API Reference:

--- a/docs/ventilation-systems.md
+++ b/docs/ventilation-systems.md
@@ -1,0 +1,134 @@
+---
+title: Ventilation systems
+---
+
+# Explicit ventilation-system construction
+
+Use `PhVentilationSystem.balanced_hrv()` when a selected HRV or ERV is known.
+The factory validates the unit type, recovery/electric ranges, and duct
+directions; preserves zero or many exterior duct elements; and returns an
+independent system graph. It does not choose equipment, invent ducts, or attach
+the system to a Room.
+
+## Supported authoring states
+
+| State | Honeybee-PH representation |
+|---|---|
+| No mechanical ventilation | Leave `room.properties.ph_hvac.ventilation_system` as `None`. |
+| Summer window ventilation | Use the existing summer daytime/nighttime window ACH inputs; keep the mechanical system as `None`. These inputs do not imply PHPP K12=3 window-only primary ventilation. |
+| Balanced HRV/ERV with no exterior ducts | Call `balanced_hrv()` with a selected `Ventilator` and omit both duct collections. |
+| Balanced HRV/ERV with modeled exterior ducts | Pass explicit supply elements with `duct_type=1` and exhaust elements with `duct_type=2`. Each element may contain one or more caller-defined segments. |
+
+Honeybee-PH does not currently author PHPP's primary “Only window
+ventilation” mode. That state needs its own authoritative source model and must
+not be inferred from summer-window ACH.
+
+## Balanced system without exterior ducts
+
+Set every unit field from the selected equipment and project data. The factory
+requires sensible recovery greater than zero and no greater than one, latent
+recovery from zero through one, and nonnegative electric efficiency. It does
+not validate quantity, frost-control settings, or unit location.
+The values below are illustrative selected/project inputs, not library
+recommendations.
+
+```python
+from honeybee.room import Room
+
+from honeybee_phhvac.ventilation import PhVentilationSystem, Ventilator
+
+room = Room.from_box("Apartment")
+unit = Ventilator()
+unit.display_name = "Selected ERV"
+unit.quantity = 1
+unit.sensible_heat_recovery = 0.82
+unit.latent_heat_recovery = 0.45
+unit.electric_efficiency = 0.35
+unit.frost_protection_reqd = True
+unit.temperature_below_defrost_used = -5.0
+unit.in_conditioned_space = True
+unit.subsoil_heat_exchange_efficiency = None
+unit.preheated_intake_temperature_c = None
+
+system = PhVentilationSystem.balanced_hrv(
+    unit,
+    display_name="Apartment ERV",
+)
+
+# Attachment is an explicit caller action.
+room.properties.ph_hvac.set_ventilation_system(system)
+```
+
+Omitting `supply_ducting` and `exhaust_ducting`, or passing empty collections,
+means no exterior duct elements are modeled. It is not shorthand for unknown
+ducts and does not create a default length.
+
+## Balanced system with exterior ducts
+
+Build segments from actual geometry and physical attributes, group them into
+typed exterior duct elements, and pass those elements to the factory.
+
+```python
+from ladybug_geometry.geometry3d.pointvector import Point3D
+from ladybug_geometry.geometry3d.polyline import LineSegment3D
+
+from honeybee_phhvac.ducting import PhDuctElement, PhDuctSegment
+from honeybee_phhvac.ventilation import PhVentilationSystem, Ventilator
+
+unit = Ventilator()
+unit.display_name = "Selected ERV"
+unit.quantity = 1
+unit.sensible_heat_recovery = 0.82
+unit.latent_heat_recovery = 0.45
+unit.electric_efficiency = 0.35
+unit.frost_protection_reqd = True
+unit.temperature_below_defrost_used = -5.0
+unit.in_conditioned_space = True
+unit.subsoil_heat_exchange_efficiency = None
+unit.preheated_intake_temperature_c = None
+
+supply_geometry = LineSegment3D.from_end_points(
+    Point3D(0, 0, 0), Point3D(2.4, 0, 0)
+)
+exhaust_geometry = LineSegment3D.from_end_points(
+    Point3D(0, 1, 0), Point3D(1.8, 1, 0)
+)
+
+supply = PhDuctElement("Exterior supply", _duct_type=1)
+supply.add_segment(PhDuctSegment(supply_geometry, _diameter=0.2))
+
+exhaust = PhDuctElement("Exterior exhaust", _duct_type=2)
+exhaust.add_segment(PhDuctSegment(exhaust_geometry, _diameter=0.2))
+
+system = PhVentilationSystem.balanced_hrv(
+    unit,
+    supply_ducting=[supply],
+    exhaust_ducting=[exhaust],
+    display_name="Apartment ERV",
+)
+```
+
+The returned system owns duplicates of the unit, elements, segments, geometry,
+and nested `user_data`. Caller-owned inputs can therefore be reused or changed
+without mutating the factory result.
+
+## Migration from implicit defaults
+
+Do not use a bare `Ventilator()` plus
+`PhDuctElement.default_supply_duct()` / `default_exhaust_duct()` as a nominal
+HRV. A bare unit has zero sensible recovery, while each default duct helper
+creates a physical 1 m segment; together they encode specific, generally false
+performance and geometry.
+
+Instead:
+
+1. Leave the Room ventilation system as `None` when no mechanical system is
+   selected.
+2. Populate a `Ventilator` from selected equipment data.
+3. Call `balanced_hrv()` with empty duct collections when there truly are no
+   exterior ducts, or pass elements built from known exterior duct geometry.
+
+There is intentionally no `preliminary_balanced_hrv()` preset. Sensible and
+latent recovery, fan power, frost protection, unit location, and exterior duct
+assumptions require an accepted, cited assumption set before such a preset can
+be added.

--- a/honeybee_ph/_epw.py
+++ b/honeybee_ph/_epw.py
@@ -15,7 +15,8 @@ from ladybug.epw import EPW
 from ladybug.skymodel import calc_horizontal_infrared
 from ladybug.wea import Wea
 
-from honeybee_ph.site import ClimateProvenance, Climate_MonthlyValueSet, _is_finite_real
+from honeybee_ph.site import ClimateProvenance, Climate_MonthlyValueSet
+from honeybee_ph_utils.validation import is_finite_real as _is_finite_real
 
 
 class EPWConversionResult(object):

--- a/honeybee_ph/site.py
+++ b/honeybee_ph/site.py
@@ -3,9 +3,7 @@
 
 """Passive-House Style Monthly Climate Data"""
 
-import math
 from copy import copy, deepcopy
-from numbers import Real
 
 try:
     from itertools import izip as zip  # type: ignore
@@ -18,6 +16,7 @@ except ImportError:
     pass  # IronPython 2.7
 
 from honeybee_ph import _base
+from honeybee_ph_utils.validation import is_finite_real as _is_finite_real
 
 
 def _finite_value_issue(field_name, value):
@@ -25,11 +24,6 @@ def _finite_value_issue(field_name, value):
     if not _is_finite_real(value):
         return "{}: expected a finite numeric value; got {!r}.".format(field_name, value)
     return None
-
-
-def _is_finite_real(value):
-    # type: (Any) -> bool
-    return not isinstance(value, bool) and isinstance(value, Real) and not math.isnan(value) and not math.isinf(value)
 
 
 class Climate_MonthlyValueSet(_base._Base):

--- a/honeybee_ph_utils/validation.py
+++ b/honeybee_ph_utils/validation.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# -*- Python Version: 2.7 -*-
+
+"""Shared validation predicates for Honeybee-PH data models."""
+
+import math
+from numbers import Real
+
+try:
+    from typing import Any
+except ImportError:
+    pass  # IronPython 2.7
+
+
+def is_finite_real(value):
+    # type: (Any) -> bool
+    """Return True for finite real numbers, excluding booleans."""
+    return not isinstance(value, bool) and isinstance(value, Real) and not math.isnan(value) and not math.isinf(value)

--- a/honeybee_phhvac/ducting.py
+++ b/honeybee_phhvac/ducting.py
@@ -104,11 +104,10 @@ class PhDuctSegment(_base._PhHVACBase):
 
         return cls(geom)
 
-    def __copy__(self):
-        # type: () -> PhDuctSegment
-        new_obj = PhDuctSegment(self.geometry)
-
-        new_obj.geometry = self.geometry
+    def _duplicate_with_geometry(self, geometry):
+        # type: (LineSegment3D) -> PhDuctSegment
+        """Duplicate metadata around an already-copied/transformed geometry."""
+        new_obj = PhDuctSegment(geometry)
         new_obj.insulation_thickness = self.insulation_thickness
         new_obj.insulation_conductivity = self.insulation_conductivity
         new_obj.insulation_reflective = self.insulation_reflective
@@ -120,6 +119,10 @@ class PhDuctSegment(_base._PhHVACBase):
         new_obj.user_data = deepcopy(self.user_data)
 
         return new_obj
+
+    def __copy__(self):
+        # type: () -> PhDuctSegment
+        return self._duplicate_with_geometry(self.geometry.duplicate())
 
     def duplicate(self):
         # type: () -> PhDuctSegment
@@ -176,9 +179,7 @@ class PhDuctSegment(_base._PhHVACBase):
         --------
             * PhDuctSegment: A new moved duct segment.
         """
-        new_segment = self.duplicate()
-        new_segment.geometry = self.geometry.move(moving_vec3D)
-        return new_segment
+        return self._duplicate_with_geometry(self.geometry.move(moving_vec3D))
 
     def rotate(self, axis_vec3D, angle_degrees, origin_pt3D):
         # type: (Point3D, float, Point3D) -> PhDuctSegment
@@ -198,9 +199,8 @@ class PhDuctSegment(_base._PhHVACBase):
         --------
             * PhDuctSegment: A new rotated duct segment.
         """
-        new_segment = self.duplicate()
-        new_segment.geometry = self.geometry.rotate(axis_vec3D, radians(angle_degrees), origin_pt3D)
-        return new_segment
+        geometry = self.geometry.rotate(axis_vec3D, radians(angle_degrees), origin_pt3D)
+        return self._duplicate_with_geometry(geometry)
 
     def rotate_xy(self, angle_degrees, origin_pt3D):
         # type: (float, Point3D) -> PhDuctSegment
@@ -215,9 +215,8 @@ class PhDuctSegment(_base._PhHVACBase):
         --------
             * PhDuctSegment: A new rotated duct segment.
         """
-        new_segment = self.duplicate()
-        new_segment.geometry = self.geometry.rotate_xy(radians(angle_degrees), origin_pt3D)
-        return new_segment
+        geometry = self.geometry.rotate_xy(radians(angle_degrees), origin_pt3D)
+        return self._duplicate_with_geometry(geometry)
 
     def reflect(self, normal_vec3D, origin_pt3D):
         # type: (Point3D, Point3D) -> PhDuctSegment
@@ -233,9 +232,7 @@ class PhDuctSegment(_base._PhHVACBase):
         --------
             * PhDuctSegment: A new reflected duct segment.
         """
-        new_segment = self.duplicate()
-        new_segment.geometry = self.geometry.reflect(normal_vec3D, origin_pt3D)
-        return new_segment
+        return self._duplicate_with_geometry(self.geometry.reflect(normal_vec3D, origin_pt3D))
 
     def scale(self, scale_factor, origin_pt3D=None):
         # type: (float, Optional[Point3D]) -> PhDuctSegment
@@ -251,8 +248,7 @@ class PhDuctSegment(_base._PhHVACBase):
         --------
             * PhDuctSegment: A new scaled duct segment.
         """
-        new_segment = self.duplicate()
-        new_segment.geometry = self.geometry.scale(scale_factor, origin_pt3D)
+        new_segment = self._duplicate_with_geometry(self.geometry.scale(scale_factor, origin_pt3D))
         new_segment.insulation_thickness = self.insulation_thickness * scale_factor
         new_segment.diameter = self.diameter * scale_factor
         new_segment.height = scale_factor * self.height if self.height else None
@@ -374,18 +370,22 @@ class PhDuctElement(_base._PhHVACBase):
         """Clear all the segments from the duct element."""
         self._segments = {}
 
-    def __copy__(self):
+    def _duplicate_without_segments(self):
         # type: () -> PhDuctElement
+        """Duplicate element metadata without copying its segment collection."""
         new_obj = PhDuctElement()
-
-        for segment in self.segments:
-            new_obj.add_segment(segment.duplicate())
-
         new_obj.identifier = self.identifier
         new_obj.display_name = self.display_name
         new_obj.duct_type = self.duct_type
         new_obj.user_data = deepcopy(self.user_data)
 
+        return new_obj
+
+    def __copy__(self):
+        # type: () -> PhDuctElement
+        new_obj = self._duplicate_without_segments()
+        for segment in self.segments:
+            new_obj.add_segment(segment.duplicate())
         return new_obj
 
     def duplicate(self):
@@ -443,8 +443,7 @@ class PhDuctElement(_base._PhHVACBase):
         --------
             * PhDuctElement: A new moved duct element.
         """
-        new_element = self.duplicate()
-        new_element.clear_segments()
+        new_element = self._duplicate_without_segments()
         for segment in self.segments:
             new_element.add_segment(segment.move(moving_vec3D))
         return new_element
@@ -466,8 +465,7 @@ class PhDuctElement(_base._PhHVACBase):
         --------
             * PhDuctElement: A new rotated duct element.
         """
-        new_element = self.duplicate()
-        new_element.clear_segments()
+        new_element = self._duplicate_without_segments()
         for segment in self.segments:
             new_element.add_segment(segment.rotate(axis_vec3D, angle_degrees, origin_pt3D))
         return new_element
@@ -484,8 +482,7 @@ class PhDuctElement(_base._PhHVACBase):
         --------
             * PhDuctElement: A new rotated duct element.
         """
-        new_element = self.duplicate()
-        new_element.clear_segments()
+        new_element = self._duplicate_without_segments()
         for segment in self.segments:
             new_element.add_segment(segment.rotate_xy(angle_degrees, origin_pt3D))
         return new_element
@@ -503,8 +500,7 @@ class PhDuctElement(_base._PhHVACBase):
         --------
             * PhDuctElement: A new reflected duct element.
         """
-        new_element = self.duplicate()
-        new_element.clear_segments()
+        new_element = self._duplicate_without_segments()
         for segment in self.segments:
             new_element.add_segment(segment.reflect(normal_vec3D, origin_pt3D))
         return new_element
@@ -523,8 +519,7 @@ class PhDuctElement(_base._PhHVACBase):
         --------
             * PhDuctElement: A new scaled duct element.
         """
-        new_element = self.duplicate()
-        new_element.clear_segments()
+        new_element = self._duplicate_without_segments()
         for segment in self.segments:
             new_element.add_segment(segment.scale(scale_factor, origin_pt3D))
         return new_element

--- a/honeybee_phhvac/ducting.py
+++ b/honeybee_phhvac/ducting.py
@@ -3,6 +3,7 @@
 
 """Honeybee-PH-HVAC-Equipment: Ducts."""
 
+from copy import deepcopy
 from math import radians
 
 try:
@@ -116,7 +117,7 @@ class PhDuctSegment(_base._PhHVACBase):
         new_obj.width = self.width
         new_obj.identifier = self.identifier
         new_obj.display_name = self.display_name
-        new_obj.user_data = self.user_data
+        new_obj.user_data = deepcopy(self.user_data)
 
         return new_obj
 
@@ -383,7 +384,7 @@ class PhDuctElement(_base._PhHVACBase):
         new_obj.identifier = self.identifier
         new_obj.display_name = self.display_name
         new_obj.duct_type = self.duct_type
-        new_obj.user_data = self.user_data
+        new_obj.user_data = deepcopy(self.user_data)
 
         return new_obj
 

--- a/honeybee_phhvac/properties/model.py
+++ b/honeybee_phhvac/properties/model.py
@@ -86,7 +86,11 @@ class ModelPhHvacProperties(object):
         for room_dict in data:
             d = room_dict.get("ventilation_system", {})
             if d:
-                mechanical_systems["ventilation_systems"][d["identifier"]] = PhVentilationSystem.from_dict(d)
+                ventilation_system = PhVentilationSystem.from_dict(d)
+                existing_system = mechanical_systems["ventilation_systems"].get(d["identifier"])
+                if existing_system and existing_system.to_dict() != ventilation_system.to_dict():
+                    raise ValueError("Conflicting ventilation systems share identifier {!r}.".format(d["identifier"]))
+                mechanical_systems["ventilation_systems"][d["identifier"]] = ventilation_system
 
             for d in room_dict.get("heating_systems", []):
                 mechanical_systems["heating_systems"][d["identifier"]] = PhHeatingSystemBuilder.from_dict(d)

--- a/honeybee_phhvac/ventilation.py
+++ b/honeybee_phhvac/ventilation.py
@@ -368,7 +368,7 @@ class PhVentilationSystem(_base._PhHVACBase):
         obj.sys_type = _input_dict["sys_type"]
         obj.supply_ducting = [ducting.PhDuctElement.from_dict(s_duct) for s_duct in _input_dict["supply_ducting"]]
         obj.exhaust_ducting = [ducting.PhDuctElement.from_dict(e_duct) for e_duct in _input_dict["exhaust_ducting"]]
-        obj.id_num = _input_dict.get("id_num", 0)
+        obj.id_num = _input_dict.get("id_num", obj.id_num)
 
         vent_unit_dict = _input_dict.get("ventilation_unit", None)
         if vent_unit_dict:
@@ -376,20 +376,26 @@ class PhVentilationSystem(_base._PhHVACBase):
 
         return obj
 
-    def duplicate(self):
+    def _duplicate_without_ducts(self):
         # type: () -> PhVentilationSystem
+        """Duplicate system metadata and equipment without copying duct collections."""
         new_obj = self.__class__()
         new_obj.display_name = self.display_name
         new_obj.identifier = self.identifier
-        new_obj.user_data = copy(self.user_data)
+        new_obj.user_data = deepcopy(self.user_data)
         new_obj.sys_type = self.sys_type
-        new_obj.supply_ducting = [s_duct.duplicate() for s_duct in self.supply_ducting]
-        new_obj.exhaust_ducting = [e_duct.duplicate() for e_duct in self.exhaust_ducting]
         new_obj.id_num = self.id_num
 
         if self.ventilation_unit:
             new_obj._ventilation_unit = self.ventilation_unit.duplicate()
 
+        return new_obj
+
+    def duplicate(self):
+        # type: () -> PhVentilationSystem
+        new_obj = self._duplicate_without_ducts()
+        new_obj.supply_ducting = [s_duct.duplicate() for s_duct in self.supply_ducting]
+        new_obj.exhaust_ducting = [e_duct.duplicate() for e_duct in self.exhaust_ducting]
         return new_obj
 
     def __copy__(self):
@@ -417,8 +423,7 @@ class PhVentilationSystem(_base._PhHVACBase):
         --------
             * PhVentilationSystem: A new system with moved ducts.
         """
-        new_system = self.duplicate()
-        new_system.identifier = self.identifier
+        new_system = self._duplicate_without_ducts()
         new_system.supply_ducting = [duct_element.move(moving_vec3D) for duct_element in self.supply_ducting]
         new_system.exhaust_ducting = [duct_element.move(moving_vec3D) for duct_element in self.exhaust_ducting]
         return new_system
@@ -440,8 +445,7 @@ class PhVentilationSystem(_base._PhHVACBase):
         --------
             * PhVentilationSystem: A new system with rotated ducts.
         """
-        new_system = self.duplicate()
-        new_system.identifier = self.identifier
+        new_system = self._duplicate_without_ducts()
         new_system.supply_ducting = [
             duct_element.rotate(axis_vec3D, angle_degrees, origin_pt3D) for duct_element in self.supply_ducting
         ]
@@ -462,8 +466,7 @@ class PhVentilationSystem(_base._PhHVACBase):
         --------
             * PhVentilationSystem: A new system with rotated ducts.
         """
-        new_system = self.duplicate()
-        new_system.identifier = self.identifier
+        new_system = self._duplicate_without_ducts()
         new_system.supply_ducting = [
             duct_element.rotate_xy(angle_degrees, origin_pt3D) for duct_element in self.supply_ducting
         ]
@@ -484,8 +487,7 @@ class PhVentilationSystem(_base._PhHVACBase):
         --------
             * PhVentilationSystem: A new system with reflected ducts.
         """
-        new_system = self.duplicate()
-        new_system.identifier = self.identifier
+        new_system = self._duplicate_without_ducts()
         new_system.supply_ducting = [
             duct_element.reflect(normal_vec3D, origin_pt3D) for duct_element in self.supply_ducting
         ]
@@ -508,8 +510,7 @@ class PhVentilationSystem(_base._PhHVACBase):
         --------
             * PhVentilationSystem: A new system with scaled ducts.
         """
-        new_system = self.duplicate()
-        new_system.identifier = self.identifier
+        new_system = self._duplicate_without_ducts()
         new_system.supply_ducting = [
             duct_element.scale(scale_factor, origin_pt3D) for duct_element in self.supply_ducting
         ]

--- a/honeybee_phhvac/ventilation.py
+++ b/honeybee_phhvac/ventilation.py
@@ -186,6 +186,10 @@ class Ventilator(_base._PhHVACBase):
 class PhVentilationSystem(_base._PhHVACBase):
     """Passive House Fresh-Air Ventilation System.
 
+    Construct a selected balanced HRV/ERV with ``balanced_hrv()``. Represent
+    no mechanical ventilation as ``None`` on the Room HVAC properties; summer
+    window ACH inputs are separate and do not create this object.
+
     Attributes:
         display_name (str): User-facing name for the ventilation system.
         sys_type (int): System type identifier (1 = Balanced PH ventilation with HR).
@@ -213,12 +217,13 @@ class PhVentilationSystem(_base._PhHVACBase):
         display_name=None,
     ):
         # type: (Ventilator, Optional[List[ducting.PhDuctElement]], Optional[List[ducting.PhDuctElement]], Optional[str]) -> PhVentilationSystem
-        """Create a balanced HRV/ERV system from explicit equipment.
+        """Create a balanced HRV/ERV system from selected equipment.
 
-        The caller-supplied ventilator and duct elements are validated and
-        duplicated. ``None`` or an empty duct collection means that no exterior
-        duct elements are modeled; this method never creates default ducts and
-        does not attach the returned system to a Room.
+        The required ventilator type, recovery/electric ranges, and duct
+        directions are validated; accepted children are duplicated. ``None``
+        or an empty duct collection means that no exterior duct elements are
+        modeled. This method never creates default ducts, chooses preliminary
+        performance, or attaches the returned system to a Room.
 
         Arguments:
         ----------

--- a/honeybee_phhvac/ventilation.py
+++ b/honeybee_phhvac/ventilation.py
@@ -4,7 +4,7 @@
 """Honeybee-PH-HVAC-Equipment: Ventilation (ERV) Devices."""
 
 import sys
-from copy import copy
+from copy import copy, deepcopy
 
 try:
     from typing import Any, Dict, List, Optional
@@ -20,6 +20,48 @@ try:
     from honeybee_phhvac import _base, ducting
 except ImportError as e:
     raise ImportError("\nFailed to import honeybee_phhvac:\n\t{}".format(e))
+
+try:
+    from honeybee_ph_utils.validation import is_finite_real
+except ImportError as e:
+    raise ImportError("\nFailed to import honeybee_ph_utils:\n\t{}".format(e))
+
+
+# -----------------------------------------------------------------------------
+
+
+def _validated_finite_number(_value, _field_name):
+    # type: (Any, str) -> Any
+    """Return a finite real value or raise an error naming the physical field."""
+    if not is_finite_real(_value):
+        raise ValueError("{} must be a finite number; got {!r}.".format(_field_name, _value))
+    return _value
+
+
+def _validated_duct_collection(_ducts, _field_name, _duct_type):
+    # type: (Optional[List[ducting.PhDuctElement]], str, int) -> List[ducting.PhDuctElement]
+    """Return a validated duct-element list for one airflow direction."""
+    if _ducts is None:
+        return []
+
+    try:
+        duct_elements = list(_ducts)
+    except TypeError:
+        raise TypeError("{} must be an iterable of PhDuctElement objects.".format(_field_name))
+
+    for duct_element in duct_elements:
+        if not isinstance(duct_element, ducting.PhDuctElement):
+            raise TypeError("{} must contain only PhDuctElement objects.".format(_field_name))
+        if duct_element.duct_type != _duct_type:
+            raise ValueError(
+                "{} contains {!r} with duct_type={!r}; expected duct_type={}.".format(
+                    _field_name,
+                    duct_element.display_name,
+                    duct_element.duct_type,
+                    _duct_type,
+                )
+            )
+    return duct_elements
 
 
 # -----------------------------------------------------------------------------
@@ -111,7 +153,7 @@ class Ventilator(_base._PhHVACBase):
         new_obj = Ventilator()
         new_obj.display_name = self.display_name
         new_obj.identifier = self.identifier
-        new_obj.user_data = copy(self.user_data)
+        new_obj.user_data = deepcopy(self.user_data)
         new_obj.id_num = self.id_num
         new_obj.quantity = self.quantity
         new_obj.sensible_heat_recovery = self.sensible_heat_recovery
@@ -161,6 +203,74 @@ class PhVentilationSystem(_base._PhHVACBase):
         self.exhaust_ducting = []  # type: List[ducting.PhDuctElement]
         self._ventilation_unit = None  # type: Optional[Ventilator]
         self.id_num = 0
+
+    @classmethod
+    def balanced_hrv(
+        cls,
+        ventilator,
+        supply_ducting=None,
+        exhaust_ducting=None,
+        display_name=None,
+    ):
+        # type: (Ventilator, Optional[List[ducting.PhDuctElement]], Optional[List[ducting.PhDuctElement]], Optional[str]) -> PhVentilationSystem
+        """Create a balanced HRV/ERV system from explicit equipment.
+
+        The caller-supplied ventilator and duct elements are validated and
+        duplicated. ``None`` or an empty duct collection means that no exterior
+        duct elements are modeled; this method never creates default ducts and
+        does not attach the returned system to a Room.
+
+        Arguments:
+        ----------
+            * ventilator (Ventilator): A selected ventilation unit with finite,
+                valid recovery and electric-efficiency values.
+            * supply_ducting (Optional[Iterable[PhDuctElement]]): Supply-air
+                duct elements (duct_type=1). Defaults to no exterior ducts.
+            * exhaust_ducting (Optional[Iterable[PhDuctElement]]): Exhaust-air
+                duct elements (duct_type=2). Defaults to no exterior ducts.
+            * display_name (Optional[str]): User-facing system name.
+
+        Returns:
+        --------
+            * PhVentilationSystem: A new, unattached balanced system that owns
+                duplicates of all supplied children.
+        """
+        if not isinstance(ventilator, Ventilator):
+            raise TypeError("ventilator must be a Ventilator object.")
+
+        sensible = _validated_finite_number(ventilator.sensible_heat_recovery, "sensible_heat_recovery")
+        if not 0.0 < sensible <= 1.0:
+            raise ValueError(
+                "sensible_heat_recovery must be greater than 0 and no greater than 1; got {!r}.".format(
+                    ventilator.sensible_heat_recovery
+                )
+            )
+
+        latent = _validated_finite_number(ventilator.latent_heat_recovery, "latent_heat_recovery")
+        if not 0.0 <= latent <= 1.0:
+            raise ValueError(
+                "latent_heat_recovery must be between 0 and 1 inclusive; got {!r}.".format(
+                    ventilator.latent_heat_recovery
+                )
+            )
+
+        electric = _validated_finite_number(ventilator.electric_efficiency, "electric_efficiency")
+        if electric < 0.0:
+            raise ValueError(
+                "electric_efficiency must be nonnegative; got {!r}.".format(ventilator.electric_efficiency)
+            )
+
+        supply_elements = _validated_duct_collection(supply_ducting, "supply_ducting", 1)
+        exhaust_elements = _validated_duct_collection(exhaust_ducting, "exhaust_ducting", 2)
+
+        obj = cls()
+        if display_name is not None:
+            obj.display_name = display_name
+        obj.sys_type = 1
+        obj.supply_ducting = [element.duplicate() for element in supply_elements]
+        obj.exhaust_ducting = [element.duplicate() for element in exhaust_elements]
+        obj.ventilation_unit = ventilator.duplicate()
+        return obj
 
     @property
     def ventilation_unit(self):

--- a/planning/STATUS.md
+++ b/planning/STATUS.md
@@ -8,7 +8,7 @@ _Last updated: 2026-08-14_
 
 | Item | Kind | Status | Pointer |
 |------|------|--------|---------|
-| Explicit `PhVentilationSystem` factories | Feature (cross-repo) | **In progress** — Phases 01–02 complete; serialization/Room/HBJSON integration next | [`features/default-ventilation-system-factory/`](features/default-ventilation-system-factory/README.md) |
+| Explicit `PhVentilationSystem` factories | Feature (cross-repo) | **In progress** — Phases 01–03 complete; PHX/OpenPH integration next | [`features/default-ventilation-system-factory/`](features/default-ventilation-system-factory/README.md) |
 | Default dwelling identity across HBJSON round-trips | Bug fix | **Requested** — reproduced in PHX; not implemented | [`refactor/dwelling-default-roundtrip.md`](refactor/dwelling-default-roundtrip.md) |
 | Decouple "Dwelling" from `Room.zone` | Refactor (cross-repo, **primary**) | **Released** in v1.33.30 — downstream install/PHX status remains in companion docs | [`refactor/dwelling-zone-decoupling.md`](refactor/dwelling-zone-decoupling.md) → [decision 0002](../context/decisions/0002-dwelling-identity-not-room-zone.md) |
 | Multiple ventilation systems per room | Refactor | Deferred — decided NOT to implement | [`refactor/multiple-ventilation-systems.md`](refactor/multiple-ventilation-systems.md) → [decision 0001](../context/decisions/0001-no-multiple-ventilation-systems-per-room.md) |

--- a/planning/STATUS.md
+++ b/planning/STATUS.md
@@ -8,7 +8,7 @@ _Last updated: 2026-08-14_
 
 | Item | Kind | Status | Pointer |
 |------|------|--------|---------|
-| Explicit `PhVentilationSystem` factories | Feature (cross-repo) | **In progress** — Phase 01 state contract accepted; Phase 02 factory implementation next | [`features/default-ventilation-system-factory/`](features/default-ventilation-system-factory/README.md) |
+| Explicit `PhVentilationSystem` factories | Feature (cross-repo) | **In progress** — Phases 01–02 complete; serialization/Room/HBJSON integration next | [`features/default-ventilation-system-factory/`](features/default-ventilation-system-factory/README.md) |
 | Default dwelling identity across HBJSON round-trips | Bug fix | **Requested** — reproduced in PHX; not implemented | [`refactor/dwelling-default-roundtrip.md`](refactor/dwelling-default-roundtrip.md) |
 | Decouple "Dwelling" from `Room.zone` | Refactor (cross-repo, **primary**) | **Released** in v1.33.30 — downstream install/PHX status remains in companion docs | [`refactor/dwelling-zone-decoupling.md`](refactor/dwelling-zone-decoupling.md) → [decision 0002](../context/decisions/0002-dwelling-identity-not-room-zone.md) |
 | Multiple ventilation systems per room | Refactor | Deferred — decided NOT to implement | [`refactor/multiple-ventilation-systems.md`](refactor/multiple-ventilation-systems.md) → [decision 0001](../context/decisions/0001-no-multiple-ventilation-systems-per-room.md) |

--- a/planning/STATUS.md
+++ b/planning/STATUS.md
@@ -8,7 +8,7 @@ _Last updated: 2026-08-14_
 
 | Item | Kind | Status | Pointer |
 |------|------|--------|---------|
-| Explicit `PhVentilationSystem` factories | Feature (cross-repo) | **Scoped** — local API fixed; Phase 01 state matrix required before code | [`features/default-ventilation-system-factory/`](features/default-ventilation-system-factory/README.md) |
+| Explicit `PhVentilationSystem` factories | Feature (cross-repo) | **In progress** — Phase 01 state contract accepted; Phase 02 factory implementation next | [`features/default-ventilation-system-factory/`](features/default-ventilation-system-factory/README.md) |
 | Default dwelling identity across HBJSON round-trips | Bug fix | **Requested** — reproduced in PHX; not implemented | [`refactor/dwelling-default-roundtrip.md`](refactor/dwelling-default-roundtrip.md) |
 | Decouple "Dwelling" from `Room.zone` | Refactor (cross-repo, **primary**) | **Released** in v1.33.30 — downstream install/PHX status remains in companion docs | [`refactor/dwelling-zone-decoupling.md`](refactor/dwelling-zone-decoupling.md) → [decision 0002](../context/decisions/0002-dwelling-identity-not-room-zone.md) |
 | Multiple ventilation systems per room | Refactor | Deferred — decided NOT to implement | [`refactor/multiple-ventilation-systems.md`](refactor/multiple-ventilation-systems.md) → [decision 0001](../context/decisions/0001-no-multiple-ventilation-systems-per-room.md) |
@@ -87,7 +87,7 @@ invent a `None`, ID `0`, or duct fallback.
 |------|-----|------|
 | `honeybee_ph` | [`features/default-ventilation-system-factory/`](features/default-ventilation-system-factory/README.md) | Authoring-side factories + validation |
 | `PHX` | `planning/features/ventilation-assignment-semantics/` | Explicit target-neutral assignment/device representation |
-| `openph-workspace` | `planning/features/ventilation-input-semantics/` | PHPP-derived device/duct state rules + readiness |
+| `openph-workspace` | `planning/archive/dated/2026-08-14/ventilation-input-semantics/` | PHPP-derived device/duct state rules + readiness — **complete, archived** |
 
 ## Update rule
 

--- a/planning/STATUS.md
+++ b/planning/STATUS.md
@@ -8,7 +8,7 @@ _Last updated: 2026-08-14_
 
 | Item | Kind | Status | Pointer |
 |------|------|--------|---------|
-| Explicit `PhVentilationSystem` factories | Feature (cross-repo) | **In progress** — Phases 01–03 complete; PHX/OpenPH integration next | [`features/default-ventilation-system-factory/`](features/default-ventilation-system-factory/README.md) |
+| Explicit `PhVentilationSystem` factories | Feature (cross-repo) | **In progress** — Phases 01–04 complete; public docs, release, and archive next | [`features/default-ventilation-system-factory/`](features/default-ventilation-system-factory/README.md) |
 | Default dwelling identity across HBJSON round-trips | Bug fix | **Requested** — reproduced in PHX; not implemented | [`refactor/dwelling-default-roundtrip.md`](refactor/dwelling-default-roundtrip.md) |
 | Decouple "Dwelling" from `Room.zone` | Refactor (cross-repo, **primary**) | **Released** in v1.33.30 — downstream install/PHX status remains in companion docs | [`refactor/dwelling-zone-decoupling.md`](refactor/dwelling-zone-decoupling.md) → [decision 0002](../context/decisions/0002-dwelling-identity-not-room-zone.md) |
 | Multiple ventilation systems per room | Refactor | Deferred — decided NOT to implement | [`refactor/multiple-ventilation-systems.md`](refactor/multiple-ventilation-systems.md) → [decision 0001](../context/decisions/0001-no-multiple-ventilation-systems-per-room.md) |

--- a/planning/STATUS.md
+++ b/planning/STATUS.md
@@ -8,7 +8,7 @@ _Last updated: 2026-08-14_
 
 | Item | Kind | Status | Pointer |
 |------|------|--------|---------|
-| Explicit `PhVentilationSystem` factories | Feature (cross-repo) | **In progress** — Phases 01–04 complete; public docs, release, and archive next | [`features/default-ventilation-system-factory/`](features/default-ventilation-system-factory/README.md) |
+| Explicit `PhVentilationSystem` factories | Feature (cross-repo) | **Implemented** — code/docs and cross-repo gates complete; coordinated releases and archive next | [`features/default-ventilation-system-factory/`](features/default-ventilation-system-factory/README.md) |
 | Default dwelling identity across HBJSON round-trips | Bug fix | **Requested** — reproduced in PHX; not implemented | [`refactor/dwelling-default-roundtrip.md`](refactor/dwelling-default-roundtrip.md) |
 | Decouple "Dwelling" from `Room.zone` | Refactor (cross-repo, **primary**) | **Released** in v1.33.30 — downstream install/PHX status remains in companion docs | [`refactor/dwelling-zone-decoupling.md`](refactor/dwelling-zone-decoupling.md) → [decision 0002](../context/decisions/0002-dwelling-identity-not-room-zone.md) |
 | Multiple ventilation systems per room | Refactor | Deferred — decided NOT to implement | [`refactor/multiple-ventilation-systems.md`](refactor/multiple-ventilation-systems.md) → [decision 0001](../context/decisions/0001-no-multiple-ventilation-systems-per-room.md) |

--- a/planning/features/default-ventilation-system-factory/PLAN.md
+++ b/planning/features/default-ventilation-system-factory/PLAN.md
@@ -6,7 +6,7 @@ survive PHX/OpenPH without dummy devices or ducts. Implement in this order.
 | Phase | Objective | Gate |
 |---:|---|---|
 | 01 | Freeze cross-repo system/device/duct state matrix and reconcile packets | **Complete** — `STATE_TABLE.md` accepted |
-| 02 | Implement explicit local factories and validation | Phase 01 source states/names stable |
+| 02 | Implement explicit local factories and validation | **Complete** — focused factory/adjacent suites green |
 | 03 | Prove ownership, duplication, Room attachment, and HBJSON | Phase 02 focused tests green |
 | 04 | Implement/verify PHX and OpenPH semantics for every accepted state | PHX representation and OpenPH rules coordinated |
 | 05 | Record deferred preset, finish docs/full gates, release, and hand off | End-to-end state matrix green |

--- a/planning/features/default-ventilation-system-factory/PLAN.md
+++ b/planning/features/default-ventilation-system-factory/PLAN.md
@@ -5,11 +5,11 @@ survive PHX/OpenPH without dummy devices or ducts. Implement in this order.
 
 | Phase | Objective | Gate |
 |---:|---|---|
-| 01 | Freeze cross-repo system/device/duct state matrix and reconcile packets | PHPP/WUFI target research accepted |
+| 01 | Freeze cross-repo system/device/duct state matrix and reconcile packets | **Complete** — `STATE_TABLE.md` accepted |
 | 02 | Implement explicit local factories and validation | Phase 01 source states/names stable |
 | 03 | Prove ownership, duplication, Room attachment, and HBJSON | Phase 02 focused tests green |
 | 04 | Implement/verify PHX and OpenPH semantics for every accepted state | PHX representation and OpenPH rules coordinated |
-| 05 | Decide optional preset, finish docs/full gates, release, and hand off | End-to-end state matrix green |
+| 05 | Record deferred preset, finish docs/full gates, release, and hand off | End-to-end state matrix green |
 
 Phase documents:
 
@@ -22,7 +22,7 @@ Phase documents:
 ## Required cross-repo sequence
 
 ```text
-PHPP/WUFI state-table research
+PHPP/WUFI state-table research [complete]
     -> accepted honeybee-ph source states
     -> PHX explicit assignment representation
     -> OpenPH no-device/zero-duct/multi-duct behavior
@@ -32,4 +32,3 @@ PHPP/WUFI state-table research
 The explicit `balanced_hrv()` implementation may land after Phase 01 while
 downstream work continues, but this packet cannot reach Complete before Phase
 04.
-

--- a/planning/features/default-ventilation-system-factory/PLAN.md
+++ b/planning/features/default-ventilation-system-factory/PLAN.md
@@ -7,7 +7,7 @@ survive PHX/OpenPH without dummy devices or ducts. Implement in this order.
 |---:|---|---|
 | 01 | Freeze cross-repo system/device/duct state matrix and reconcile packets | **Complete** — `STATE_TABLE.md` accepted |
 | 02 | Implement explicit local factories and validation | **Complete** — focused factory/adjacent suites green |
-| 03 | Prove ownership, duplication, Room attachment, and HBJSON | Phase 02 focused tests green |
+| 03 | Prove ownership, duplication, Room attachment, and HBJSON | **Complete** — graph/HBJSON integration green |
 | 04 | Implement/verify PHX and OpenPH semantics for every accepted state | PHX representation and OpenPH rules coordinated |
 | 05 | Record deferred preset, finish docs/full gates, release, and hand off | End-to-end state matrix green |
 

--- a/planning/features/default-ventilation-system-factory/PLAN.md
+++ b/planning/features/default-ventilation-system-factory/PLAN.md
@@ -8,8 +8,8 @@ survive PHX/OpenPH without dummy devices or ducts. Implement in this order.
 | 01 | Freeze cross-repo system/device/duct state matrix and reconcile packets | **Complete** — `STATE_TABLE.md` accepted |
 | 02 | Implement explicit local factories and validation | **Complete** — focused factory/adjacent suites green |
 | 03 | Prove ownership, duplication, Room attachment, and HBJSON | **Complete** — graph/HBJSON integration green |
-| 04 | Implement/verify PHX and OpenPH semantics for every accepted state | PHX representation and OpenPH rules coordinated |
-| 05 | Record deferred preset, finish docs/full gates, release, and hand off | End-to-end state matrix green |
+| 04 | Implement/verify PHX and OpenPH semantics for every accepted state | **Complete** — PHX representation and OpenPH rules coordinated |
+| 05 | Record deferred preset, finish docs/full gates, release, and hand off | **In progress** — implementation/docs complete; coordinated release pending |
 
 Phase documents:
 
@@ -29,6 +29,6 @@ PHPP/WUFI state-table research [complete]
     -> end-to-end verification and release
 ```
 
-The explicit `balanced_hrv()` implementation may land after Phase 01 while
-downstream work continues, but this packet cannot reach Complete before Phase
-04.
+The explicit `balanced_hrv()` implementation and downstream semantics are
+complete. This packet reaches Complete only after the coordinated honeybee-ph
+and PHX releases are published and verified.

--- a/planning/features/default-ventilation-system-factory/PRD.md
+++ b/planning/features/default-ventilation-system-factory/PRD.md
@@ -1,6 +1,6 @@
 # PRD — Explicit `PhVentilationSystem` factories
 
-**Status:** Scoped · 2026-08-14
+**Status:** In progress · Phase 01 contract accepted · 2026-08-14
 **Author:** Ed May + Codex
 **Kind:** Feature (this repo, `honeybee_phhvac`) with downstream PHX/OpenPH coordination
 
@@ -22,7 +22,7 @@ system = PhVentilationSystem.balanced_hrv(
 )
 ```
 
-Optionally provide a separately named preliminary-model preset:
+The separately named preliminary-model preset is deferred from this feature:
 
 ```python
 system = PhVentilationSystem.preliminary_balanced_hrv()
@@ -46,7 +46,7 @@ serialized user data.
    must not silently pair with the current bare `Ventilator()` value of
    `sensible_heat_recovery = 0.0` unless the caller set that value deliberately
    or invoked a clearly named non-HR constructor.
-3. **Preliminary preset, if shipped.** Its complete physical assumptions are
+3. **Preliminary preset (deferred follow-up).** Its complete physical assumptions are
    documented and tested: sensible/latent recovery, specific electric power,
    frost protection, unit location, and duct representation. Values must come
    from a stated standard/library convention or be clearly marked BLDGTYP
@@ -107,7 +107,8 @@ loss, and an incomplete model.
   and duct inputs.
 - Empty duct collections remain empty and semantically meaningful.
 - No named HRV preset silently has 0% sensible recovery.
-- Any preliminary preset exposes and documents every physical assumption.
+- No preliminary preset ships without a separately accepted complete set of
+  physical assumptions.
 - Missing/no-mechanical ventilation is not encoded as an accidental device ID.
 - Factory objects are independent and round-trip through HBJSON.
 - PHX converts each supported state without inventing new physical inputs.

--- a/planning/features/default-ventilation-system-factory/PRD.md
+++ b/planning/features/default-ventilation-system-factory/PRD.md
@@ -1,6 +1,6 @@
 # PRD — Explicit `PhVentilationSystem` factories
 
-**Status:** In progress · Phase 01 contract accepted · 2026-08-14
+**Status:** Implemented · coordinated release pending · 2026-08-14
 **Author:** Ed May + Codex
 **Kind:** Feature (this repo, `honeybee_phhvac`) with downstream PHX/OpenPH coordination
 

--- a/planning/features/default-ventilation-system-factory/README.md
+++ b/planning/features/default-ventilation-system-factory/README.md
@@ -1,6 +1,6 @@
 # ventilation-system-factories — router
 
-**Status:** In progress · Phase 01 contract accepted
+**Status:** In progress · Phases 01–02 complete
 
 **Scope:** Explicit constructors for valid ventilation states in
 `honeybee_phhvac`, including a balanced HRV/ERV system without invented duct

--- a/planning/features/default-ventilation-system-factory/README.md
+++ b/planning/features/default-ventilation-system-factory/README.md
@@ -1,6 +1,6 @@
 # ventilation-system-factories — router
 
-**Status:** In progress · Phases 01–02 complete
+**Status:** In progress · Phases 01–03 complete
 
 **Scope:** Explicit constructors for valid ventilation states in
 `honeybee_phhvac`, including a balanced HRV/ERV system without invented duct

--- a/planning/features/default-ventilation-system-factory/README.md
+++ b/planning/features/default-ventilation-system-factory/README.md
@@ -1,6 +1,6 @@
 # ventilation-system-factories — router
 
-**Status:** Scoped · implementation not started
+**Status:** In progress · Phase 01 contract accepted
 
 **Scope:** Explicit constructors for valid ventilation states in
 `honeybee_phhvac`, including a balanced HRV/ERV system without invented duct
@@ -9,9 +9,10 @@ needed.
 
 **Read order:**
 1. `PRD.md` — what / why (behavior contract)
-2. `PLAN.md` — cross-repo phase sequence and gates
-3. `phases/phase-01-*` through `phase-05-*` — implementation handoff
-4. `STATUS.md` — current state
+2. `STATE_TABLE.md` — accepted cross-repo source/target contract
+3. `PLAN.md` — cross-repo phase sequence and gates
+4. `phases/phase-01-*` through `phase-05-*` — implementation handoff
+5. `STATUS.md` — current state
 
 **Origin:** ph-modeler POC application review (2026-08-14), ventilation and
 duct-default findings (`~/Desktop/ph-modeler/APP_REVIEW.md`).

--- a/planning/features/default-ventilation-system-factory/README.md
+++ b/planning/features/default-ventilation-system-factory/README.md
@@ -1,11 +1,11 @@
 # ventilation-system-factories — router
 
-**Status:** In progress · Phases 01–03 complete
+**Status:** Implemented · coordinated release pending · 2026-08-14
 
 **Scope:** Explicit constructors for valid ventilation states in
 `honeybee_phhvac`, including a balanced HRV/ERV system without invented duct
-lengths and a clearly named preliminary-model preset when one is genuinely
-needed.
+lengths. A preliminary-model preset is explicitly deferred until its complete
+assumption set is separately accepted.
 
 **Read order:**
 1. `PRD.md` — what / why (behavior contract)

--- a/planning/features/default-ventilation-system-factory/STATE_TABLE.md
+++ b/planning/features/default-ventilation-system-factory/STATE_TABLE.md
@@ -1,0 +1,76 @@
+# Ventilation state contract
+
+**Status:** Accepted for implementation · 2026-08-14
+
+This is the shared source contract for honeybee-ph, PHX, and OpenPH. It is
+derived from the PHPP V10.6 `Ventilation` and `Addl vent` inputs documented in
+OpenPH's completed `ventilation-input-semantics` packet. `None` means absence in
+the Python domain models; a target exporter may translate that state to a
+required numeric wire-format value, but `0` is not a device identifier or a
+domain-model sentinel.
+
+## Supported source states
+
+| Source state | honeybee-ph | PHX | OpenPH / target result |
+|---|---|---|---|
+| No mechanical system | `Room.properties.ph_hvac.ventilation_system is None` | `PhxSpace.vent_unit_id_num is None`; no device | OpenPH `NONE`; no device lookup; PHPP K12 blank |
+| Summer window ventilation | Existing summer daytime/nighttime window ACH data; no `PhVentilationSystem` | Existing summer-ventilation fields; no device assignment | Existing summer calculation; independent of PHPP K12 |
+| Balanced HRV/ERV, no exterior ducts | `balanced_hrv(unit)` or empty duct collections | One real device; zero duct elements | `BALANCED_PH_WITH_HR`; duct coefficient `exp(0) = 1.0` |
+| Balanced HRV/ERV, one/many duct elements | Explicit typed supply/exhaust collections | Preserve elements and their segments | Preserve elements to the PHPP boundary; sum coefficients in the exponent |
+| Mechanical system missing a device | Invalid source | Conversion fails before adding rooms/devices | No placeholder or downstream lookup |
+| Unresolved PHX device reference | Not constructible from a valid conversion | Invalid PHX variant | Aggregate diagnostic names Space and missing device ID |
+
+The PHPP primary `3-Only window ventilation` / K12=3 state is not currently
+authorable from honeybee-ph. `PhVentilationSystem` carries mechanical device
+data, and existing window inputs describe summer ventilation only. K12=3 is
+therefore explicitly deferred; it must not be inferred from summer ACH data or
+encoded as an empty mechanical system.
+
+## Mechanical-system rules
+
+| PHPP K12 state | Device | Exterior ducts | Assignment |
+|---|---|---|---|
+| `1-Balanced PH ventilation with HR` | Required | 0..n supply and 0..n exhaust elements | Every mechanically served Space resolves to the real device |
+| `2-Extract air unit` | Required | 0..n elements, normally exhaust | Every mechanically served Space resolves to the real device |
+| `3-Only window ventilation` | Forbidden | None | No device assignment; source authoring deferred |
+| Blank / no selection | Forbidden | None | No device assignment |
+
+`balanced_hrv()` implements only the first row. It requires an explicit
+`Ventilator`, duplicates all accepted children, sets `sys_type=1`, creates no
+ducts implicitly, and does not attach itself to a Room.
+
+## Duct preservation and PHPP aggregation
+
+PHX preserves every `PhxDuctElement` and its constituent segments. The
+canonical formulas and cell evidence live in OpenPH's archived
+`ventilation-input-semantics/STATE_TABLE.md`, under “Exterior Duct Rows.” The
+source-model consequences are:
+
+- zero rows produce `EXP(0) = 1.0`, so no exterior duct loss is a valid state;
+- multiple elements remain distinct until the target applies its documented
+  aggregation;
+- a zero-length or zero-airflow row contributes zero;
+- no 1 m duct may be manufactured as a cardinality fallback.
+
+## PHX boundary rules
+
+- `PhxSpace.vent_unit_id_num` is `Optional[int]` with a default of `None`.
+- honeybee-ph conversion creates a PHX device only from a real source
+  `Ventilator`; an incomplete mechanical source fails with a targeted message.
+- variant validation reports all unresolved Space/device and duct/device
+  references before target output starts.
+- WUFI XML and METr JSON emit numeric `0` under the accepted legacy writer
+  convention; WUFI import normalizes blank/`0` back to `None`. This is target
+  adaptation, not PHX domain state or a claim about the external schemas.
+- PHPP skips assignment/device lookup for `None`.
+- OpenPH consumes `None` directly and temporarily continues accepting legacy
+  PHX `0` input as a compatibility alias.
+
+## Factory and preset decision
+
+The explicit `balanced_hrv(ventilator, ...)` constructor is approved. A
+`preliminary_balanced_hrv()` preset remains deferred: no complete, accepted
+source currently fixes sensible/latent recovery, specific electric power,
+frost protection, location, and duct assumptions. The feature will ship
+without guessed performance values unless those assumptions are separately
+accepted.

--- a/planning/features/default-ventilation-system-factory/STATUS.md
+++ b/planning/features/default-ventilation-system-factory/STATUS.md
@@ -1,6 +1,6 @@
 # STATUS — ventilation-system-factories
 
-**Status:** In progress · Phases 01–02 complete · 2026-08-14
+**Status:** In progress · Phases 01–03 complete · 2026-08-14
 
 - Phase 01 froze the shared honeybee-ph / PHX / OpenPH state contract in
   `STATE_TABLE.md`.
@@ -20,8 +20,16 @@
 - `None` and empty duct collections remain empty; accepted caller children and
   nested `user_data` are independently duplicated; no legacy default-duct
   helper is called and no Room attachment occurs.
-- **Next step:** Phase 03 serialization, duplication, Room, Model, and HBJSON
-  round-trip coverage.
+- Phase 03 proves zero/one/many-duct dictionary round trips, full graph
+  independence including geometry and nested metadata, explicit Room
+  attachment, real HBJSON file transport, shared-system deduplication, and
+  preservation of distinct system identifiers.
+- Same-identifier/different-payload system graphs now fail with a targeted
+  conflict instead of silently overwriting one graph during Model reload.
+- Transform paths reuse metadata-only duplicates and no longer allocate and
+  discard intermediate geometry graphs.
+- **Next step:** Phase 04 PHX nullable assignment, converter validation, target
+  mappings, and OpenPH compatibility verification.
 - The optional preliminary preset remains deferred because no complete set of
   performance, frost, location, and duct assumptions has been accepted.
 - Phase 01 gate: simplify reuse/quality/efficiency findings resolved;
@@ -32,3 +40,6 @@
   the new factory/helpers; **135 adjacent factory/duct/climate tests** pass;
   Black, Python 2 grammar parsing, and `git diff --check` pass.
 - Phase 02 full gate: **1004 tests** pass with **80%** aggregate coverage.
+- Phase 03 focused/adjacent gate: **115 tests** pass; Black, Python 2 grammar,
+  and `git diff --check` pass before the full phase gate.
+- Phase 03 full gate: **1016 tests** pass with **80%** aggregate coverage.

--- a/planning/features/default-ventilation-system-factory/STATUS.md
+++ b/planning/features/default-ventilation-system-factory/STATUS.md
@@ -1,6 +1,6 @@
 # STATUS — ventilation-system-factories
 
-**Status:** In progress · Phases 01–03 complete · 2026-08-14
+**Status:** In progress · Phases 01–04 complete · 2026-08-14
 
 - Phase 01 froze the shared honeybee-ph / PHX / OpenPH state contract in
   `STATE_TABLE.md`.
@@ -28,8 +28,11 @@
   conflict instead of silently overwriting one graph during Model reload.
 - Transform paths reuse metadata-only duplicates and no longer allocate and
   discard intermediate geometry graphs.
-- **Next step:** Phase 04 PHX nullable assignment, converter validation, target
-  mappings, and OpenPH compatibility verification.
+- Phase 04 gives PHX an explicit nullable assignment, mutation-free source
+  preflight, aggregate Space/duct readiness, and target-specific mappings;
+  OpenPH compatibility passes without fabricated equipment or duct lengths.
+- **Next step:** Phase 05 public constructor/state documentation, deferred
+  preset record, full gates, coordinated versions/pins, release, and archive.
 - The optional preliminary preset remains deferred because no complete set of
   performance, frost, location, and duct assumptions has been accepted.
 - Phase 01 gate: simplify reuse/quality/efficiency findings resolved;
@@ -43,3 +46,12 @@
 - Phase 03 focused/adjacent gate: **115 tests** pass; Black, Python 2 grammar,
   and `git diff --check` pass before the full phase gate.
 - Phase 03 full gate: **1016 tests** pass with **80%** aggregate coverage.
+- Phase 04 affected PHX gate: **516 passed**, **3 skipped**; focused OpenPH
+  **29 passed** and openph-demand **4 passed** against updated source paths.
+- Phase 04 full PHX gate: **901 passed**, **3 skipped**, **1 deselected**;
+  Black and `git diff --check` pass.
+- Phase 04 full honeybee-ph gate: **1016 tests** pass with **80%** aggregate
+  coverage.
+- Phase 04 direct Honeybee → HBJSON → PHX → OpenPH matrix passes for no
+  mechanical equipment and balanced systems with zero or two duct elements per
+  direction.

--- a/planning/features/default-ventilation-system-factory/STATUS.md
+++ b/planning/features/default-ventilation-system-factory/STATUS.md
@@ -1,6 +1,6 @@
 # STATUS — ventilation-system-factories
 
-**Status:** In progress · Phases 01–04 complete · 2026-08-14
+**Status:** Implemented · coordinated release pending · 2026-08-14
 
 - Phase 01 froze the shared honeybee-ph / PHX / OpenPH state contract in
   `STATE_TABLE.md`.
@@ -31,8 +31,10 @@
 - Phase 04 gives PHX an explicit nullable assignment, mutation-free source
   preflight, aggregate Space/duct readiness, and target-specific mappings;
   OpenPH compatibility passes without fabricated equipment or duct lengths.
-- **Next step:** Phase 05 public constructor/state documentation, deferred
-  preset record, full gates, coordinated versions/pins, release, and archive.
+- Phase 05 adds the public constructor/state guide, migration guidance, and
+  decision 0006; the optional preliminary preset remains deferred.
+- **Next step:** run the final Phase 05 gates, publish coordinated versions,
+  record minimum pins, verify installed artifacts, and archive both packets.
 - The optional preliminary preset remains deferred because no complete set of
   performance, frost, location, and duct assumptions has been accepted.
 - Phase 01 gate: simplify reuse/quality/efficiency findings resolved;
@@ -55,3 +57,6 @@
 - Phase 04 direct Honeybee → HBJSON → PHX → OpenPH matrix passes for no
   mechanical equipment and balanced systems with zero or two duct elements per
   direction.
+- Phase 05 pre-release gate: both exact public examples execute independently;
+  Black, Python 2 grammar parsing, and `git diff --check` pass; the full suite
+  passes **1016 tests** with **80%** aggregate coverage.

--- a/planning/features/default-ventilation-system-factory/STATUS.md
+++ b/planning/features/default-ventilation-system-factory/STATUS.md
@@ -1,6 +1,6 @@
 # STATUS — ventilation-system-factories
 
-**Status:** In progress · Phase 01 complete · 2026-08-14
+**Status:** In progress · Phases 01–02 complete · 2026-08-14
 
 - Phase 01 froze the shared honeybee-ph / PHX / OpenPH state contract in
   `STATE_TABLE.md`.
@@ -15,11 +15,20 @@
   preserved to the PHPP boundary and summed in the PHPP exponent.
 - Existing honeybee-ph window ACH describes summer ventilation only. Primary
   PHPP K12=3 window-only authoring is explicitly deferred rather than inferred.
-- **Next step:** Phase 02 tests-first implementation of `balanced_hrv()` and
-  its field/direction validation.
+- Phase 02 added the IronPython-safe `balanced_hrv()` classmethod with explicit
+  unit, finite/range, collection/member, and duct-direction validation.
+- `None` and empty duct collections remain empty; accepted caller children and
+  nested `user_data` are independently duplicated; no legacy default-duct
+  helper is called and no Room attachment occurs.
+- **Next step:** Phase 03 serialization, duplication, Room, Model, and HBJSON
+  round-trip coverage.
 - The optional preliminary preset remains deferred because no complete set of
   performance, frost, location, and duct assumptions has been accepted.
 - Phase 01 gate: simplify reuse/quality/efficiency findings resolved;
   docs-pass found no broken links or stale status language;
   `.venv/bin/python -m coverage run && ... coverage report` passed with
   **966 tests** and **80%** aggregate coverage.
+- Phase 02 focused gates: **38 factory tests** pass with no uncovered lines in
+  the new factory/helpers; **135 adjacent factory/duct/climate tests** pass;
+  Black, Python 2 grammar parsing, and `git diff --check` pass.
+- Phase 02 full gate: **1004 tests** pass with **80%** aggregate coverage.

--- a/planning/features/default-ventilation-system-factory/STATUS.md
+++ b/planning/features/default-ventilation-system-factory/STATUS.md
@@ -1,19 +1,25 @@
 # STATUS — ventilation-system-factories
 
-**Status:** Scoped · 2026-08-14
+**Status:** In progress · Phase 01 complete · 2026-08-14
 
-- Filed from the ph-modeler POC architecture review; implementation not
-  started.
+- Phase 01 froze the shared honeybee-ph / PHX / OpenPH state contract in
+  `STATE_TABLE.md`.
 - Review revised the request: the current bare unit has 0% sensible recovery
   and the current default ducts each create a physical 1 m segment. Their
   composition is not a neutral balanced-HRV default.
 - Public `balanced_hrv()` signature, ownership, empty-duct, validation, and
   no-mechanical contracts are fixed in `PRD.md`.
-- **Next step:** execute Phase 01 jointly against the PHX/OpenPH packets: derive
-  and accept the system/device/duct state matrix before implementation.
-- Cross-repo dependency: PHX/OpenPH must accept explicit no-device and
-  no-exterior-duct states before those states can pass the full pipeline.
-- Blocker: select/document the source of any shipped preliminary performance
-  values. The explicit constructor taking a real `Ventilator` is not blocked.
-- A preliminary preset is optional and must be omitted—not guessed—if its
-  assumptions are not accepted.
+- Accepted absence is `None` in the domain models. Numeric `0` is limited to
+  required target-format adaptation and temporary legacy OpenPH input support.
+- Zero exterior duct elements is a valid lossless state; multiple elements are
+  preserved to the PHPP boundary and summed in the PHPP exponent.
+- Existing honeybee-ph window ACH describes summer ventilation only. Primary
+  PHPP K12=3 window-only authoring is explicitly deferred rather than inferred.
+- **Next step:** Phase 02 tests-first implementation of `balanced_hrv()` and
+  its field/direction validation.
+- The optional preliminary preset remains deferred because no complete set of
+  performance, frost, location, and duct assumptions has been accepted.
+- Phase 01 gate: simplify reuse/quality/efficiency findings resolved;
+  docs-pass found no broken links or stale status language;
+  `.venv/bin/python -m coverage run && ... coverage report` passed with
+  **966 tests** and **80%** aggregate coverage.

--- a/planning/features/default-ventilation-system-factory/phases/phase-01-cross-repo-state-contract.md
+++ b/planning/features/default-ventilation-system-factory/phases/phase-01-cross-repo-state-contract.md
@@ -1,5 +1,7 @@
 # Phase 01 — Cross-repo ventilation state contract
 
+**Status:** Complete · 2026-08-14
+
 ## Objective
 
 Derive one reviewed state table for honeybee-ph, PHX, PHPP/WUFI export, and
@@ -18,7 +20,7 @@ OpenPH before naming factories or encoding absence.
 3. Reconcile these packets so they describe the same contract:
    - this packet;
    - `PHX/planning/features/ventilation-assignment-semantics/`;
-   - `openph-workspace/planning/features/ventilation-input-semantics/`.
+   - `openph-workspace/planning/archive/dated/2026-08-14/ventilation-input-semantics/`.
 4. Remove the stale OpenPH planning statement that describes the honeybee-ph
    factory as a default ventilator plus default ducts.
 
@@ -42,3 +44,16 @@ OpenPH before naming factories or encoding absence.
 - The local `balanced_hrv()` signature in the PRD remains compatible with the
   accepted matrix.
 
+## Outcome
+
+All exit checks are recorded in `../STATE_TABLE.md`. The accepted model uses
+`None` for no assignment, optional empty exterior-duct collections, and
+PHPP-faithful multi-element aggregation. Summer window ACH remains supported;
+primary PHPP K12=3 window-only authoring is deferred because honeybee-ph has no
+source field carrying that choice. The optional preliminary preset is also
+deferred pending accepted physical assumptions.
+
+Verification: the three simplify reviews were resolved, docs-pass found no
+broken links or stale status statements, and the full honeybee-ph coverage gate
+passed with 966 tests and 80% aggregate coverage. The coordinated PHX full gate
+passed with 881 tests, 3 skipped, and 1 deselected.

--- a/planning/features/default-ventilation-system-factory/phases/phase-02-explicit-factories-and-validation.md
+++ b/planning/features/default-ventilation-system-factory/phases/phase-02-explicit-factories-and-validation.md
@@ -1,5 +1,7 @@
 # Phase 02 — Explicit factories and validation
 
+**Status:** Complete · 2026-08-14
+
 ## Objective
 
 Implement physically honest local construction for an explicit balanced
@@ -34,3 +36,16 @@ HRV/ERV without changing legacy constructors or inventing ducts.
 - Existing constructor/duct tests remain unchanged and pass.
 - No preliminary performance preset is added in this phase.
 
+## Outcome
+
+`PhVentilationSystem.balanced_hrv()` now implements the accepted constructor.
+The tests cover required equipment, all performance boundaries and invalid
+finite/range cases, `None`/empty/one/many ducts, collection and direction
+errors, child ownership, nested metadata independence, deterministic naming,
+no default-duct calls, and no Room attachment. The finite-real predicate is
+shared with climate/EPW validation through `honeybee_ph_utils.validation`.
+
+Verification before the full phase gate: 38 focused factory tests pass with no
+uncovered lines in the new factory/helper code; 135 adjacent HVAC/climate tests
+pass; Black, Python 2 grammar parsing, and `git diff --check` pass. The full
+repository gate passes with 1004 tests and 80% aggregate coverage.

--- a/planning/features/default-ventilation-system-factory/phases/phase-03-serialization-and-room-integration.md
+++ b/planning/features/default-ventilation-system-factory/phases/phase-03-serialization-and-room-integration.md
@@ -1,5 +1,7 @@
 # Phase 03 — Serialization and Room integration
 
+**Status:** Complete · 2026-08-14
+
 ## Objective
 
 Prove every local factory state through duplicate, Room properties, model
@@ -28,3 +30,22 @@ collection deduplication, and HBJSON without changing attachment semantics.
 - Existing valid HBJSON payloads remain byte-shape compatible unless an
   additive key was explicitly accepted in Phase 01.
 
+## Outcome
+
+All zero/one/many-duct states round-trip through system dictionaries, full and
+abridged Room properties, and a real HBJSON file. Direct, Room, and transformed
+duplicates own independent system, ventilator, duct element, segment, geometry,
+and nested metadata graphs. Public two-Room Model round trips prove identical
+system identifiers deduplicate to one shared restored object and distinct
+identifiers remain distinct.
+
+Model reload now rejects a same-identifier/different-payload ventilation
+collision instead of silently keeping the last graph. Required historical
+system keys remain required; genuinely optional metadata (`user_data`,
+`id_num`) remains tolerant. Transform implementations reuse metadata-only copy
+helpers so the stronger geometry-ownership contract does not allocate and
+discard intermediate graphs.
+
+Verification before the full phase gate: 115 focused/adjacent tests pass;
+Black, Python 2 grammar parsing, and `git diff --check` pass. The full repository
+gate passes with 1016 tests and 80% aggregate coverage.

--- a/planning/features/default-ventilation-system-factory/phases/phase-04-phx-openph-integration.md
+++ b/planning/features/default-ventilation-system-factory/phases/phase-04-phx-openph-integration.md
@@ -14,14 +14,14 @@ blank ventilators, and two artificial 1 m ducts.
 4. Validate unresolved references before export and return all issues together.
 5. Keep valid existing mechanical fixtures and target writes unchanged.
 
-## OpenPH work
+## OpenPH compatibility verification
 
-1. Accept valid no-mechanical and zero-exterior-duct states.
-2. Reject incomplete mechanical systems before device-property access.
-3. Implement the documented PHPP-faithful multi-element rule at the target
-   boundary; do not collapse the PHX model prematurely.
-4. Compare Ventilation, SummVent, Heating, and Cooling cells/results against a
-   controlled PHPP reference.
+OpenPH's archived `ventilation-input-semantics` work already accepts valid
+no-mechanical and zero-exterior-duct states, rejects incomplete assignments,
+and implements PHPP-faithful multi-element aggregation. Do not duplicate that
+implementation. Verify the updated PHX model against the completed OpenPH
+contract and retain its legacy PHX `0` input test until the published PHX pin
+can make that compatibility path removable.
 
 ## End-to-end matrix
 
@@ -40,5 +40,5 @@ absence of placeholders.
 - Valid empty duct collections calculate without fabricated lengths.
 - Existing valid mechanical reference outputs remain unchanged unless a
   separately documented fidelity fix was accepted.
-- Full relevant suites in honeybee-ph, PHX, OpenPH, and openph-demand pass.
-
+- Full relevant suites in honeybee-ph and PHX pass; focused OpenPH and
+  openph-demand compatibility suites pass against the updated PHX model.

--- a/planning/features/default-ventilation-system-factory/phases/phase-04-phx-openph-integration.md
+++ b/planning/features/default-ventilation-system-factory/phases/phase-04-phx-openph-integration.md
@@ -1,5 +1,7 @@
 # Phase 04 — PHX/OpenPH integration
 
+**Status:** Complete · 2026-08-14
+
 ## Objective
 
 Remove the downstream conditions that forced callers to create device ID `0`,
@@ -42,3 +44,21 @@ absence of placeholders.
   separately documented fidelity fix was accepted.
 - Full relevant suites in honeybee-ph and PHX pass; focused OpenPH and
   openph-demand compatibility suites pass against the updated PHX model.
+
+## Outcome
+
+PHX now represents no Space assignment as `None`, rejects source mechanical
+systems without a real ventilation unit before any mutation, and aggregates
+Space plus collection-scoped duct reference issues before export. PHPP skips
+unassigned lookup; WUFI/METr adapt `None` to legacy numeric `0`; WUFI import
+normalizes missing/blank/`0` back to `None`. PPP, PHPP, WUFI, and METr project
+entry points preflight before generating output.
+
+The affected PHX surface passes 516 tests with 3 expected skips. Against the
+updated honeybee-ph + PHX source graph, 29 focused OpenPH tests and 4
+openph-demand tests pass. A direct Honeybee Room/HVAC → HBJSON → PHX → OpenPH
+matrix passes for no mechanical equipment and balanced systems with zero or
+two supply/exhaust ducts; no placeholder units or duct lengths are created.
+The full PHX gate passes with 901 tests, 3 skipped, and 1 deselected; the full
+honeybee-ph gate passes with 1,016 tests and 80% aggregate coverage. All
+simplify reuse, quality, and efficiency findings were resolved.

--- a/planning/features/default-ventilation-system-factory/phases/phase-05-preset-docs-and-release.md
+++ b/planning/features/default-ventilation-system-factory/phases/phase-05-preset-docs-and-release.md
@@ -1,14 +1,15 @@
-# Phase 05 — Preset decision, docs, and release
+# Phase 05 — Deferred preset, docs, and release
 
 ## Objective
 
-Decide the optional preliminary preset, document every supported state, run
-full gates, and release the coordinated contract.
+Record the preliminary preset as a deferred follow-up, document every supported
+state, run full gates, and release the coordinated contract.
 
-## Preliminary preset gate
+## Deferred preliminary preset
 
-Add `preliminary_balanced_hrv()` only if Ed accepts a complete, cited assumption
-set covering:
+This feature ships without `preliminary_balanced_hrv()`. A future packet may
+propose it only with Ed's acceptance of a complete, cited assumption set
+covering:
 
 - sensible and latent recovery;
 - electric efficiency/specific fan power;
@@ -17,8 +18,7 @@ set covering:
 - supply/exhaust exterior duct representation;
 - display/provenance label identifying assumed—not selected—equipment.
 
-If any value remains unresolved, record the preset as Deferred and complete the
-feature without it. Never fill gaps from current defaults.
+Never fill gaps from current defaults.
 
 ## Docs and verification
 
@@ -37,6 +37,6 @@ feature without it. Never fill gaps from current defaults.
 ## Exit checks
 
 - Every documented constructor state passes the end-to-end matrix.
-- Optional preset is either fully specified/tested or explicitly deferred.
+- Preliminary preset is explicitly deferred to a separately accepted packet.
 - No public example contains dummy ID `0`, zero-recovery HRV, or invented duct.
 - Released versions and downstream compatibility requirements are recorded.

--- a/planning/features/default-ventilation-system-factory/phases/phase-05-preset-docs-and-release.md
+++ b/planning/features/default-ventilation-system-factory/phases/phase-05-preset-docs-and-release.md
@@ -1,5 +1,7 @@
 # Phase 05 — Deferred preset, docs, and release
 
+**Status:** In progress · implementation and public docs complete; release pending
+
 ## Objective
 
 Record the preliminary preset as a deferred follow-up, document every supported
@@ -40,3 +42,17 @@ Never fill gaps from current defaults.
 - Preliminary preset is explicitly deferred to a separately accepted packet.
 - No public example contains dummy ID `0`, zero-recovery HRV, or invented duct.
 - Released versions and downstream compatibility requirements are recorded.
+
+## Pre-release outcome
+
+`docs/ventilation-systems.md` documents every supported authoring state and
+migration away from bare equipment plus default 1 m ducts. Both Python examples
+execute independently and explicitly set all ventilator fields that flow
+downstream; their values are labeled illustrative, not recommended defaults.
+Decision 0006 preserves the stable state/absence/deferred-preset contract.
+
+The preliminary preset remains deferred. All simplify reuse, quality, and
+efficiency findings are resolved, with the decision-record research link
+scheduled to follow the packet into `planning/archive/` after release. Black,
+Python 2 grammar parsing, `git diff --check`, and the exact public examples
+pass. The full suite passes 1,016 tests with 80% aggregate coverage.

--- a/tests/test_honeybee_phhvac/test_systems/test_ventilation_system_factory.py
+++ b/tests/test_honeybee_phhvac/test_systems/test_ventilation_system_factory.py
@@ -1,0 +1,218 @@
+import math
+
+import pytest
+
+from honeybee_phhvac import ventilation
+from honeybee_phhvac.ducting import PhDuctElement, PhDuctSegment
+from honeybee_phhvac.properties.room import RoomPhHvacProperties
+
+
+def _valid_ventilator():
+    unit = ventilation.Ventilator()
+    unit.display_name = "Selected ERV"
+    unit.sensible_heat_recovery = 0.82
+    unit.latent_heat_recovery = 0.45
+    unit.electric_efficiency = 0.35
+    return unit
+
+
+def test_balanced_hrv_requires_a_ventilator():
+    with pytest.raises(TypeError, match="ventilator"):
+        ventilation.PhVentilationSystem.balanced_hrv(None)
+
+    with pytest.raises(TypeError, match="ventilator"):
+        ventilation.PhVentilationSystem.balanced_hrv(object())
+
+
+def test_balanced_hrv_with_no_exterior_ducts():
+    unit = _valid_ventilator()
+
+    system = ventilation.PhVentilationSystem.balanced_hrv(unit)
+
+    assert system.sys_type == 1
+    assert system.supply_ducting == []
+    assert system.exhaust_ducting == []
+    assert system.ventilation_unit.to_dict() == unit.to_dict()
+    assert system.ventilation_unit is not unit
+
+
+def test_balanced_hrv_treats_none_and_empty_duct_collections_equally():
+    unit = _valid_ventilator()
+
+    with_none = ventilation.PhVentilationSystem.balanced_hrv(unit, supply_ducting=None, exhaust_ducting=None)
+    with_empty = ventilation.PhVentilationSystem.balanced_hrv(unit, supply_ducting=[], exhaust_ducting=[])
+
+    assert with_none.supply_ducting == with_empty.supply_ducting == []
+    assert with_none.exhaust_ducting == with_empty.exhaust_ducting == []
+
+
+def test_balanced_hrv_accepts_and_duplicates_multiple_typed_ducts():
+    unit = _valid_ventilator()
+    supply_1 = PhDuctElement("Supply 1", _duct_type=1)
+    supply_2 = PhDuctElement("Supply 2", _duct_type=1)
+    exhaust_1 = PhDuctElement("Exhaust 1", _duct_type=2)
+    exhaust_2 = PhDuctElement("Exhaust 2", _duct_type=2)
+
+    system = ventilation.PhVentilationSystem.balanced_hrv(
+        unit,
+        supply_ducting=(supply_1, supply_2),
+        exhaust_ducting=[exhaust_1, exhaust_2],
+        display_name="Apartment ERV",
+    )
+
+    assert system.display_name == "Apartment ERV"
+    assert [d.to_dict() for d in system.supply_ducting] == [
+        supply_1.to_dict(),
+        supply_2.to_dict(),
+    ]
+    assert [d.to_dict() for d in system.exhaust_ducting] == [
+        exhaust_1.to_dict(),
+        exhaust_2.to_dict(),
+    ]
+    assert system.supply_ducting[0] is not supply_1
+    assert system.supply_ducting[1] is not supply_2
+    assert system.exhaust_ducting[0] is not exhaust_1
+    assert system.exhaust_ducting[1] is not exhaust_2
+
+
+def test_balanced_hrv_does_not_rename_caller_owned_ventilator():
+    unit = _valid_ventilator()
+    unit.display_name = "_unnamed_ventilator_"
+
+    system = ventilation.PhVentilationSystem.balanced_hrv(unit, display_name="Apartment ERV")
+
+    assert unit.display_name == "_unnamed_ventilator_"
+    assert system.ventilation_unit.display_name == "Apartment ERV"
+
+
+def test_balanced_hrv_uses_default_system_name_for_unnamed_child():
+    unit = _valid_ventilator()
+    unit.display_name = "_unnamed_ventilator_"
+
+    system = ventilation.PhVentilationSystem.balanced_hrv(unit)
+
+    assert system.display_name == "_unnamed_ph_vent_system_"
+    assert system.ventilation_unit.display_name == system.display_name
+
+
+def test_balanced_hrv_returns_fresh_independent_children():
+    unit = _valid_ventilator()
+    supply = PhDuctElement("Supply", _duct_type=1)
+
+    system_1 = ventilation.PhVentilationSystem.balanced_hrv(unit, [supply])
+    system_2 = ventilation.PhVentilationSystem.balanced_hrv(unit, [supply])
+
+    assert system_1 is not system_2
+    assert system_1.ventilation_unit is not system_2.ventilation_unit
+    assert system_1.supply_ducting[0] is not system_2.supply_ducting[0]
+
+
+def test_balanced_hrv_children_own_nested_user_data():
+    unit = _valid_ventilator()
+    unit.user_data = {"selection": {"source": "caller"}}
+    segment = PhDuctSegment.default()
+    segment.user_data = {"geometry": {"source": "caller"}}
+    supply = PhDuctElement("Supply", _duct_type=1)
+    supply.user_data = {"element": {"source": "caller"}}
+    supply.add_segment(segment)
+
+    system = ventilation.PhVentilationSystem.balanced_hrv(unit, [supply])
+    system.ventilation_unit.user_data["selection"]["source"] = "result"
+    system.supply_ducting[0].user_data["element"]["source"] = "result"
+    system.supply_ducting[0].segments[0].user_data["geometry"]["source"] = "result"
+
+    assert unit.user_data["selection"]["source"] == "caller"
+    assert supply.user_data["element"]["source"] == "caller"
+    assert segment.user_data["geometry"]["source"] == "caller"
+    assert system.supply_ducting[0].segments[0] is not segment
+
+
+def test_balanced_hrv_does_not_attach_to_room_properties():
+    room_properties = RoomPhHvacProperties(_host=None)
+
+    system = ventilation.PhVentilationSystem.balanced_hrv(_valid_ventilator())
+
+    assert system is not None
+    assert room_properties.ventilation_system is None
+
+
+@pytest.mark.parametrize(
+    "value",
+    [0.0, -0.1, 1.1, math.nan, math.inf, -math.inf, None, True, "0.8"],
+)
+def test_balanced_hrv_rejects_invalid_sensible_heat_recovery(value):
+    unit = _valid_ventilator()
+    unit.sensible_heat_recovery = value
+
+    with pytest.raises(ValueError, match="sensible_heat_recovery"):
+        ventilation.PhVentilationSystem.balanced_hrv(unit)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [-0.1, 1.1, math.nan, math.inf, -math.inf, None, "0.4"],
+)
+def test_balanced_hrv_rejects_invalid_latent_heat_recovery(value):
+    unit = _valid_ventilator()
+    unit.latent_heat_recovery = value
+
+    with pytest.raises(ValueError, match="latent_heat_recovery"):
+        ventilation.PhVentilationSystem.balanced_hrv(unit)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [-0.1, math.nan, math.inf, -math.inf, None, "0.35"],
+)
+def test_balanced_hrv_rejects_invalid_electric_efficiency(value):
+    unit = _valid_ventilator()
+    unit.electric_efficiency = value
+
+    with pytest.raises(ValueError, match="electric_efficiency"):
+        ventilation.PhVentilationSystem.balanced_hrv(unit)
+
+
+def test_balanced_hrv_accepts_performance_boundaries():
+    unit = _valid_ventilator()
+    unit.sensible_heat_recovery = 1.0
+    unit.latent_heat_recovery = 0.0
+    unit.electric_efficiency = 0.0
+    ventilation.PhVentilationSystem.balanced_hrv(unit)
+
+    unit.latent_heat_recovery = 1.0
+    ventilation.PhVentilationSystem.balanced_hrv(unit)
+
+
+@pytest.mark.parametrize("ducts", [object(), 1, "supply"])
+def test_balanced_hrv_rejects_invalid_duct_collections(ducts):
+    with pytest.raises(TypeError, match="supply_ducting"):
+        ventilation.PhVentilationSystem.balanced_hrv(_valid_ventilator(), supply_ducting=ducts)
+
+
+def test_balanced_hrv_rejects_non_duct_collection_members():
+    with pytest.raises(TypeError, match="exhaust_ducting"):
+        ventilation.PhVentilationSystem.balanced_hrv(_valid_ventilator(), exhaust_ducting=[object()])
+
+
+def test_balanced_hrv_rejects_wrong_duct_direction():
+    exhaust = PhDuctElement("Wrong supply direction", _duct_type=2)
+    supply = PhDuctElement("Wrong exhaust direction", _duct_type=1)
+
+    with pytest.raises(ValueError, match="supply_ducting"):
+        ventilation.PhVentilationSystem.balanced_hrv(_valid_ventilator(), supply_ducting=[exhaust])
+
+    with pytest.raises(ValueError, match="exhaust_ducting"):
+        ventilation.PhVentilationSystem.balanced_hrv(_valid_ventilator(), exhaust_ducting=[supply])
+
+
+def test_balanced_hrv_never_calls_legacy_default_duct_helpers(monkeypatch):
+    def fail(*args, **kwargs):
+        raise AssertionError("legacy default duct helper called")
+
+    monkeypatch.setattr(PhDuctElement, "default_supply_duct", fail)
+    monkeypatch.setattr(PhDuctElement, "default_exhaust_duct", fail)
+
+    system = ventilation.PhVentilationSystem.balanced_hrv(_valid_ventilator())
+
+    assert system.supply_ducting == []
+    assert system.exhaust_ducting == []

--- a/tests/test_honeybee_phhvac/test_systems/test_ventilation_system_integration.py
+++ b/tests/test_honeybee_phhvac/test_systems/test_ventilation_system_integration.py
@@ -1,0 +1,182 @@
+import pytest
+from honeybee.model import Model
+from honeybee.room import Room
+from ladybug_geometry.geometry3d.pointvector import Vector3D
+
+from honeybee_phhvac import ventilation
+from honeybee_phhvac.ducting import PhDuctElement, PhDuctSegment
+from honeybee_phhvac.properties.room import RoomPhHvacProperties
+
+
+def _factory_system(duct_count=0, display_name="Balanced ERV"):
+    unit = ventilation.Ventilator()
+    unit.display_name = "Selected ERV"
+    unit.sensible_heat_recovery = 0.82
+    unit.latent_heat_recovery = 0.45
+    unit.electric_efficiency = 0.35
+    unit.user_data = {"selection": {"status": "selected"}}
+
+    supply_ducts = []
+    exhaust_ducts = []
+    for index in range(duct_count):
+        supply = PhDuctElement("Supply {}".format(index + 1), _duct_type=1)
+        supply.user_data = {"element": {"index": index}}
+        supply_segment = PhDuctSegment.default()
+        supply_segment.user_data = {"segment": {"index": index}}
+        supply.add_segment(supply_segment)
+        supply_ducts.append(supply)
+
+        exhaust = PhDuctElement("Exhaust {}".format(index + 1), _duct_type=2)
+        exhaust.user_data = {"element": {"index": index}}
+        exhaust_segment = PhDuctSegment.default()
+        exhaust_segment.user_data = {"segment": {"index": index}}
+        exhaust.add_segment(exhaust_segment)
+        exhaust_ducts.append(exhaust)
+
+    system = ventilation.PhVentilationSystem.balanced_hrv(
+        unit,
+        supply_ducting=supply_ducts,
+        exhaust_ducting=exhaust_ducts,
+        display_name=display_name,
+    )
+    system.user_data = {"system": {"source": "factory"}}
+    return system
+
+
+@pytest.mark.parametrize("duct_count", [0, 1, 2])
+def test_factory_system_dict_round_trip(duct_count):
+    system = _factory_system(duct_count)
+
+    restored = ventilation.PhVentilationSystem.from_dict(system.to_dict())
+
+    assert restored.to_dict() == system.to_dict()
+    assert len(restored.supply_ducting) == duct_count
+    assert len(restored.exhaust_ducting) == duct_count
+
+
+def test_factory_system_duplicate_owns_full_graph():
+    system = _factory_system(2)
+
+    duplicate = system.duplicate()
+
+    assert duplicate.to_dict() == system.to_dict()
+    assert duplicate is not system
+    assert duplicate.ventilation_unit is not system.ventilation_unit
+    assert duplicate.supply_ducting[0] is not system.supply_ducting[0]
+    assert duplicate.supply_ducting[0].segments[0] is not system.supply_ducting[0].segments[0]
+    assert duplicate.supply_ducting[0].segments[0].geometry is not system.supply_ducting[0].segments[0].geometry
+
+    duplicate.user_data["system"]["source"] = "duplicate"
+    duplicate.ventilation_unit.user_data["selection"]["status"] = "duplicate"
+    duplicate.supply_ducting[0].user_data["element"]["index"] = 99
+    duplicate.supply_ducting[0].segments[0].user_data["segment"]["index"] = 99
+
+    assert system.user_data["system"]["source"] == "factory"
+    assert system.ventilation_unit.user_data["selection"]["status"] == "selected"
+    assert system.supply_ducting[0].user_data["element"]["index"] == 0
+    assert system.supply_ducting[0].segments[0].user_data["segment"]["index"] == 0
+
+
+@pytest.mark.parametrize("abridged", [False, True])
+def test_factory_system_room_properties_round_trip(abridged):
+    properties = RoomPhHvacProperties(_host=None)
+    properties.set_ventilation_system(_factory_system(2))
+
+    payload = properties.to_dict(abridged=abridged)
+    restored = RoomPhHvacProperties.from_dict(payload["ph_hvac"], host=None)
+
+    assert restored.to_dict(abridged=abridged) == payload
+
+
+def test_factory_system_hbjson_model_round_trip(tmp_path):
+    room = Room.from_box("FactoryRoom")
+    room.properties.ph_hvac.set_ventilation_system(_factory_system(2))
+    model = Model("FactoryModel", rooms=[room])
+
+    hbjson_path = model.to_hbjson(name="factory-model.hbjson", folder=str(tmp_path))
+    restored = Model.from_hbjson(hbjson_path)
+
+    restored_system = restored.rooms[0].properties.ph_hvac.ventilation_system
+    assert restored_system.to_dict() == room.properties.ph_hvac.ventilation_system.to_dict()
+    assert len(restored_system.supply_ducting) == 2
+    assert len(restored_system.exhaust_ducting) == 2
+
+
+def test_hbjson_model_round_trip_deduplicates_shared_identifier():
+    shared_system = _factory_system(1)
+    first = Room.from_box("SharedFirst")
+    second = Room.from_box("SharedSecond")
+    first.properties.ph_hvac.set_ventilation_system(shared_system)
+    second.properties.ph_hvac.set_ventilation_system(shared_system.duplicate())
+    model = Model("SharedSystemModel", rooms=[first, second])
+
+    restored = Model.from_dict(model.to_dict())
+    restored_first = restored.rooms[0].properties.ph_hvac.ventilation_system
+    restored_second = restored.rooms[1].properties.ph_hvac.ventilation_system
+
+    assert restored_first is restored_second
+    assert restored_first.identifier == shared_system.identifier
+
+
+def test_hbjson_model_round_trip_preserves_distinct_systems():
+    first_system = _factory_system(1, "First ERV")
+    second_system = _factory_system(1, "Second ERV")
+    first = Room.from_box("DistinctFirst")
+    second = Room.from_box("DistinctSecond")
+    first.properties.ph_hvac.set_ventilation_system(first_system)
+    second.properties.ph_hvac.set_ventilation_system(second_system)
+    model = Model("DistinctSystemModel", rooms=[first, second])
+
+    restored = Model.from_dict(model.to_dict())
+    restored_first = restored.rooms[0].properties.ph_hvac.ventilation_system
+    restored_second = restored.rooms[1].properties.ph_hvac.ventilation_system
+
+    assert restored_first is not restored_second
+    assert {restored_first.identifier, restored_second.identifier} == {
+        first_system.identifier,
+        second_system.identifier,
+    }
+
+
+def test_room_duplicate_and_transform_do_not_mutate_source_system():
+    room = Room.from_box("TransformRoom")
+    room.properties.ph_hvac.set_ventilation_system(_factory_system(1))
+    source_system = room.properties.ph_hvac.ventilation_system
+    source_geometry = source_system.supply_ducting[0].segments[0].geometry.to_dict()
+
+    duplicate = room.duplicate()
+    duplicate.move(Vector3D(2, 0, 0))
+    duplicate_system = duplicate.properties.ph_hvac.ventilation_system
+
+    assert source_system.supply_ducting[0].segments[0].geometry.to_dict() == source_geometry
+    assert duplicate_system.supply_ducting[0].segments[0].geometry.to_dict() != source_geometry
+    assert duplicate_system.ventilation_unit.to_dict() == source_system.ventilation_unit.to_dict()
+    assert duplicate_system.identifier == source_system.identifier
+    assert duplicate_system is not source_system
+
+
+def test_hbjson_rejects_same_identifier_with_conflicting_system_graphs():
+    source = Room.from_box("CollisionSource")
+    source.properties.ph_hvac.set_ventilation_system(_factory_system(1))
+    moved = source.duplicate()
+    moved.identifier = "CollisionMoved"
+    moved.move(Vector3D(2, 0, 0))
+    model = Model("ConflictingSystemModel", rooms=[source, moved])
+
+    with pytest.raises(Exception, match="Conflicting ventilation systems share identifier"):
+        Model.from_dict(model.to_dict())
+
+
+def test_legacy_system_dict_without_optional_metadata_loads():
+    payload = ventilation.PhVentilationSystem().to_dict()
+    payload.pop("user_data")
+    payload.pop("id_num")
+
+    restored = ventilation.PhVentilationSystem.from_dict(payload)
+
+    assert restored.sys_type == 1
+    assert restored.user_data == {}
+    assert restored.id_num == 0
+    assert restored.ventilation_unit is None
+    assert restored.supply_ducting == []
+    assert restored.exhaust_ducting == []


### PR DESCRIPTION
## Summary
- add an explicit validated balanced HRV/ERV factory without invented ducts
- preserve independent equipment, duct, metadata, geometry, and HBJSON graphs
- document no-mechanical, summer-window, zero-duct, and modeled-duct states
- record the cross-repo PHX/OpenPH assignment and readiness contract

## Verification
- 1,016 honeybee-ph tests pass
- 80% aggregate coverage
- Black, Python 2 grammar parse, public example execution, and git diff checks pass
- PHX: 901 passed, 3 skipped, 1 deselected
- focused OpenPH: 29 passed; openph-demand: 4 passed
