### PR TITLE
Update allowed PHPP 10 IHG types to include missing type

### DIFF
--- a/honeybee_ph/phi.py
+++ b/honeybee_ph/phi.py
@@ -40,6 +40,16 @@ class EnumProperty(object):
     """
 
     allowed_inputs = {  # type: Dict[str, Dict[int, List]]
+        "phpp_version": {
+            9: [
+                "9",
+                "10",
+            ],
+            10: [
+                "9",
+                "10",
+            ]'
+        },
         "building_category_type": {
             9: [
                 "1-RESIDENTIAL BUILDING",

--- a/honeybee_ph/phi.py
+++ b/honeybee_ph/phi.py
@@ -422,7 +422,7 @@ class PhiCertification(_base._Base):
         attributes (Union[PHPPSettings9, PHPPSettings10]): Version-specific certification settings.
     """
 
-    def __init__(self, phpp_version=9):
+    def __init__(self, phpp_version):
         # type: (int) -> None
         super(PhiCertification, self).__init__()
         self.phpp_version = phpp_version

--- a/honeybee_ph/phi.py
+++ b/honeybee_ph/phi.py
@@ -40,16 +40,6 @@ class EnumProperty(object):
     """
 
     allowed_inputs = {  # type: Dict[str, Dict[int, List]]
-        "phpp_version": {
-            9: [
-                "9",
-                "10",
-            ],
-            10: [
-                "9",
-                "10",
-            ],
-        },
         "building_category_type": {
             9: [
                 "1-RESIDENTIAL BUILDING",
@@ -308,7 +298,7 @@ class _PHPPSettingsBase(object):
         tfa_override (Optional[float]): Optional override for the treated floor area.
     """
 
-    phpp_version = 9  # default
+    #phpp_version = 9  # default
     tfa_override = None  # type: float | None
 
     def to_dict(self):

--- a/honeybee_ph/phi.py
+++ b/honeybee_ph/phi.py
@@ -422,7 +422,7 @@ class PhiCertification(_base._Base):
         attributes (Union[PHPPSettings9, PHPPSettings10]): Version-specific certification settings.
     """
 
-    def __init__(self, phpp_version=9):
+    def __init__(self):
         # type: (int) -> None
         super(PhiCertification, self).__init__()
         self.phpp_version = phpp_version

--- a/honeybee_ph/phi.py
+++ b/honeybee_ph/phi.py
@@ -426,9 +426,9 @@ class PhiCertification(_base._Base):
         # type: (int) -> None
         super(PhiCertification, self).__init__()
         self.phpp_version = phpp_version
-        if self.phpp_version == 10:
+        if phpp_version == 10:
             self.attributes = PHPPSettings10()
-        elif self.phpp_version == 9:
+        elif phpp_version == 9:
             self.attributes = PHPPSettings9()
         else:
             msg = "Error: Unknown PHPP Version? Got: '{}'".format(self.phpp_version)

--- a/honeybee_ph/phi.py
+++ b/honeybee_ph/phi.py
@@ -422,7 +422,7 @@ class PhiCertification(_base._Base):
         attributes (Union[PHPPSettings9, PHPPSettings10]): Version-specific certification settings.
     """
 
-    def __init__(self):
+    def __init__(self, phpp_version=9):
         # type: (int) -> None
         super(PhiCertification, self).__init__()
         self.phpp_version = phpp_version

--- a/honeybee_ph/phi.py
+++ b/honeybee_ph/phi.py
@@ -48,7 +48,7 @@ class EnumProperty(object):
             10: [
                 "9",
                 "10",
-            ]'
+            ],
         },
         "building_category_type": {
             9: [

--- a/honeybee_ph/phi.py
+++ b/honeybee_ph/phi.py
@@ -426,7 +426,7 @@ class PhiCertification(_base._Base):
         # type: (int) -> None
         super(PhiCertification, self).__init__()
         self.phpp_version = phpp_version
-        if phpp_version == 10:
+        if self.phpp_version == 10:
             self.attributes = PHPPSettings10()
         elif self.phpp_version == 9:
             self.attributes = PHPPSettings9()

--- a/honeybee_ph/phi.py
+++ b/honeybee_ph/phi.py
@@ -422,7 +422,7 @@ class PhiCertification(_base._Base):
         attributes (Union[PHPPSettings9, PHPPSettings10]): Version-specific certification settings.
     """
 
-    def __init__(self, phpp_version):
+    def __init__(self, phpp_version=9):
         # type: (int) -> None
         super(PhiCertification, self).__init__()
         self.phpp_version = phpp_version

--- a/honeybee_ph/phi.py
+++ b/honeybee_ph/phi.py
@@ -106,7 +106,7 @@ class EnumProperty(object):
                 "4-PHPP CALCULATION ('IHG NON-RES' WORKSHEET)",
             ],
             10: [
-                "_",
+                "1-User-Defined",
                 "2-STANDARD",
                 "3-PHPP-CALCULATION ('IHG' WORKSHEET)",
                 "4-PHPP-CALCULATION ('IHG NON-RES' WORKSHEET)",

--- a/honeybee_ph/phi.py
+++ b/honeybee_ph/phi.py
@@ -100,13 +100,13 @@ class EnumProperty(object):
         },
         "ihg_type": {
             9: [
-                "_",
+                "1-USER DETERMINED",    # No interstitial dash in PHPP 9
                 "2-STANDARD",
                 "3-PHPP CALCULATION ('IHG' WORKSHEET)",
                 "4-PHPP CALCULATION ('IHG NON-RES' WORKSHEET)",
             ],
             10: [
-                "1-User-Defined",
+                "1-USER-DEFINED",
                 "2-STANDARD",
                 "3-PHPP-CALCULATION ('IHG' WORKSHEET)",
                 "4-PHPP-CALCULATION ('IHG NON-RES' WORKSHEET)",

--- a/honeybee_ph/phi.py
+++ b/honeybee_ph/phi.py
@@ -298,7 +298,7 @@ class _PHPPSettingsBase(object):
         tfa_override (Optional[float]): Optional override for the treated floor area.
     """
 
-    #phpp_version = 9  # default
+    phpp_version = 9  # default
     tfa_override = None  # type: float | None
 
     def to_dict(self):

--- a/tests/test_honeybee_ph/test_phi/test_phi_cert.py
+++ b/tests/test_honeybee_ph/test_phi/test_phi_cert.py
@@ -78,10 +78,19 @@ def test_scale_phi_cert():
     assert new_cert.to_dict() != phi_cert.to_dict()
     assert new_cert.attributes.tfa_override == 200
 
+def test_phi_cert_serialization_default_v10():
+    phi_cert = phi.PhiCertification(phpp_version=10)
+    
+    d = phi_cert.to_dict()
+    new_obj = phi.PhiCertification.from_dict(d)
+
+    assert new_obj.to_dict() == d
+
 def test_phi_cert_serialization_customized_v10():
     phi_cert = phi.PhiCertification(phpp_version=10)
 
     phi_cert_attributes = phi_cert.attributes  # type: phi.PHPPSettings10
+    phi_cert_attributes.phpp_version = "10"
     phi_cert_attributes.building_use_type = "10"
     phi_cert_attributes.ihg_type = "1"
     phi_cert_attributes.certification_class = "10"

--- a/tests/test_honeybee_ph/test_phi/test_phi_cert.py
+++ b/tests/test_honeybee_ph/test_phi/test_phi_cert.py
@@ -82,6 +82,7 @@ def test_phi_cert_serialization_customized_v10():
     phi_cert = phi.PhiCertification(phpp_version=10)
 
     phi_cert_attributes = phi_cert.attributes  # type: phi.PHPPSettings10
+    phi_cert_attributes.phpp_version = "10"
     phi_cert_attributes.building_use_type = "10"
     phi_cert_attributes.ihg_type = "1"
     phi_cert_attributes.certification_class = "10"

--- a/tests/test_honeybee_ph/test_phi/test_phi_cert.py
+++ b/tests/test_honeybee_ph/test_phi/test_phi_cert.py
@@ -79,9 +79,9 @@ def test_scale_phi_cert():
     assert new_cert.attributes.tfa_override == 200
 
 def test_phi_cert_serialization_customized_v10():
-    phi_cert = phi.PhiCertification(phpp_version=9)
+    phi_cert = phi.PhiCertification(phpp_version=10)
 
-    phi_cert_attributes = phi_cert.attributes  # type: phi.PHPPSettings10
+    phi_cert_attributes = phi_cert.attributes.PHPPSettings10  # type: phi.PHPPSettings10
     phi_cert_attributes.phpp_version = "10"
     phi_cert_attributes.building_use_type = "10"
     phi_cert_attributes.ihg_type = "1"

--- a/tests/test_honeybee_ph/test_phi/test_phi_cert.py
+++ b/tests/test_honeybee_ph/test_phi/test_phi_cert.py
@@ -81,8 +81,7 @@ def test_scale_phi_cert():
 def test_phi_cert_serialization_customized_v10():
     phi_cert = phi.PhiCertification(phpp_version=10)
 
-    phi_cert_attributes = phi_cert.attributes.PHPPSettings10  # type: phi.PHPPSettings10
-    phi_cert_attributes.phpp_version = "10"
+    phi_cert_attributes = phi_cert.attributes  # type: phi.PHPPSettings10
     phi_cert_attributes.building_use_type = "10"
     phi_cert_attributes.ihg_type = "1"
     phi_cert_attributes.certification_class = "10"

--- a/tests/test_honeybee_ph/test_phi/test_phi_cert.py
+++ b/tests/test_honeybee_ph/test_phi/test_phi_cert.py
@@ -79,7 +79,7 @@ def test_scale_phi_cert():
     assert new_cert.attributes.tfa_override == 200
 
 def test_phi_cert_serialization_customized_v10():
-    phi_cert = phi.PhiCertification(phpp_version=10)
+    phi_cert = phi.PhiCertification(phpp_version=9)
 
     phi_cert_attributes = phi_cert.attributes  # type: phi.PHPPSettings10
     phi_cert_attributes.phpp_version = "10"

--- a/tests/test_honeybee_ph/test_phi/test_phi_cert.py
+++ b/tests/test_honeybee_ph/test_phi/test_phi_cert.py
@@ -77,3 +77,20 @@ def test_scale_phi_cert():
     new_cert = phi_cert.scale(2, Point3D(0, 0, 0))
     assert new_cert.to_dict() != phi_cert.to_dict()
     assert new_cert.attributes.tfa_override == 200
+
+def test_phi_cert_serialization_customized_v10():
+    phi_cert = phi.PhiCertification(phpp_version=10)
+
+    phi_cert_attributes = phi_cert.attributes  # type: phi.PHPPSettings10
+    phi_cert_attributes.building_use_type = "10"
+    phi_cert_attributes.ihg_type = "1"
+    phi_cert_attributes.certification_class = "10"
+    phi_cert_attributes.certification_type = "10"
+    phi_cert_attributes.primary_energy_type = "1"
+    phi_cert_attributes.retrofit_type = "1"
+    phi_cert_attributes.tfa_override = 436.89
+
+    d = phi_cert.to_dict()
+    new_obj = phi.PhiCertification.from_dict(d)
+
+    assert new_obj.to_dict() == d


### PR DESCRIPTION
Updated the allowed inputs for PHPP 10 - IHG_Types to include valid "1-User-defined" IHG option in PHPP 10. component previously raised an exception.

This is related to 
https://github.com/PH-Tools/honeybee_grasshopper_ph/pull/67
and
https://github.com/PH-Tools/honeybee_grasshopper_ph/issues/66

and aligns the component accepted inputs to the tooltip stated inputs.
