### PR TITLE
fix: validate enum value before committing it in EnumProperty.__set__

### DIFF
--- a/honeybee_ph/phi.py
+++ b/honeybee_ph/phi.py
@@ -262,11 +262,11 @@ class EnumProperty(object):
         """
 
         if value:
-            instance.__dict__[self.attribute_name] = self.enum(value)
-
-        if instance.__dict__[self.attribute_name].value == "_":
-            msg = "Error: Input value: '{}' for '{}' is not allowed. Check inputs.".format(value, self.attribute_name)
-            raise Exception(msg)
+            candidate = self.enum(value)
+            if candidate.value == "_":
+                msg = "Error: Input value: '{}' for '{}' is not allowed. Check inputs.".format(value, self.attribute_name)
+                raise Exception(msg)
+            instance.__dict__[self.attribute_name] = candidate
 
     def __get__(self, instance, owner):
         # type: (Any, Any) -> enumerables.CustomEnum


### PR DESCRIPTION
Fixes #99

## Problem

`EnumProperty.__set__` in `honeybee_ph/phi.py` wrote the new value into `instance.__dict__` **before** validating it:

`python
if value:
    instance.__dict__[self.attribute_name] = self.enum(value)   # stored first

if instance.__dict__[self.attribute_name].value == "_":         # validated after
    raise Exception(msg)
`

When the incoming value resolved to the `"_"` sentinel (an invalid padding slot), the exception was raised - but the bad value was already stored. Any caller that caught the error was left with a corrupted object:

`python
settings = phi.PHPPSettings10()
print(settings.ihg_type.value)      # 2-STANDARD

try:
    settings.ihg_type = 1           # resolves to "_"
except Exception:
    pass

print(settings.ihg_type.value)      # '_'  ? should still be '2-STANDARD'
print(settings.to_dict()["ihg_type"])  # '_'  ? serialized into HBJSON
`

There is also a second-order effect: once the object is in this state, every later assignment of a falsy value (`None`, `""`, `0` - what an unconnected Grasshopper input sends) re-raises, because the `"_"` check runs against the already-stored stale value.

## Fix

Validate first, commit only on success:

`diff
-        if value:
-            instance.__dict__[self.attribute_name] = self.enum(value)
-
-        if instance.__dict__[self.attribute_name].value == "_":
-            msg = "Error: Input value: '{}' for '{}' is not allowed. Check inputs.".format(value, self.attribute_name)
-            raise Exception(msg)
+        if value:
+            candidate = self.enum(value)
+            if candidate.value == "_":
+                msg = "Error: Input value: '{}' for '{}' is not allowed. Check inputs.".format(value, self.attribute_name)
+                raise Exception(msg)
+            instance.__dict__[self.attribute_name] = candidate
`

A rejected assignment now leaves the previous value intact, and the second-order effect (spurious re-raise on subsequent falsy input) is eliminated.